### PR TITLE
feat(export): implement Excel/CSV export with styling support

### DIFF
--- a/docs/technical/excel-download-feature.md
+++ b/docs/technical/excel-download-feature.md
@@ -1,0 +1,730 @@
+# 엑셀 다운로드 기능 기획서
+
+## 1. 개요
+
+### 1.1 배경 및 목적
+
+조회 데이터를 엑셀/CSV로 내보내 분석, 보고서 작성, 공유에 활용한다.
+
+**기대 효과**:
+- DTO에 어노테이션만 추가하면 엑셀 다운로드 구현 완료
+- 100만 건 이상도 OOM 없이 처리
+- 일관된 포맷과 스타일 유지
+
+### 1.2 Quick Start
+
+```kotlin
+// 1. DTO에 어노테이션 추가
+@ExportSheet(name = "주문목록")
+data class OrderExportDto(
+    @ExportColumn(header = "주문번호", order = 1)
+    val orderNo: String,
+    @ExportColumn(header = "금액", order = 2, format = "#,##0")
+    val amount: BigDecimal,
+)
+
+// 2. Controller에서 Export 호출
+excelExporter.export(orders, OrderExportDto::class, response.outputStream)
+```
+
+---
+
+## 2. 요구사항
+
+### 2.1 기능 요구사항
+
+| 번호 | 요구사항 | 설명 |
+|------|---------|------|
+| FR-01 | DTO 기반 변환 | DTO 리스트 → 엑셀/CSV 변환 |
+| FR-02 | 어노테이션 설정 | 헤더명, 볼드, 색상, 너비를 어노테이션으로 지정 |
+| FR-03 | 타입별 포맷 | 숫자, 문자, Boolean, 날짜에 맞는 셀 포맷 적용 |
+| FR-04 | 셀 스타일링 | 헤더/바디 각각 배경색, 볼드 등 스타일 적용 |
+| FR-05 | 컬럼 순서 | 어노테이션으로 출력 순서 지정 |
+| FR-06 | CSV Export | 동일 어노테이션으로 CSV 지원 (행 제한 없음) |
+
+### 2.2 비기능 요구사항
+
+| 번호 | 요구사항 | 목표 |
+|------|---------|------|
+| NFR-01 | 대용량 처리 | 100만 건+ OOM 없이 처리 |
+| NFR-02 | 메모리 효율 | 스트리밍 방식, 힙 256MB 이내 |
+| NFR-03 | 응답 시간 | 10만 건 기준 30초 이내 |
+| NFR-04 | 비동기 처리 | 50만 건+ 비동기 다운로드 |
+
+---
+
+## 3. 기술 스택
+
+### 3.1 라이브러리 선정
+
+**Apache POI SXSSF** 사용
+
+| 고려 항목 | POI XSSF | POI SXSSF | FastExcel | EasyExcel |
+|----------|----------|-----------|-----------|-----------|
+| 대용량 | X | O (스트리밍) | O | O |
+| 스타일링 | O | O (제한적) | △ | △ |
+| Spring 호환 | O | O | O | O |
+| 문서/커뮤니티 | O | O | △ | △ |
+| 커스터마이징 | O | O | △ | X |
+
+SXSSF는 지정된 행 수만 메모리에 유지하고 나머지는 임시 파일로 flush한다.
+
+### 3.2 제약사항
+
+| 제약사항 | 설명 |
+|---------|------|
+| 쓰기 전용 | 읽기 불가, 생성 후 수정 불가 |
+| 순차 쓰기 | 임의 행 접근 불가 |
+| 스타일 제한 | 복잡한 스타일 일부 미지원 |
+
+---
+
+## 4. 설계
+
+### 4.1 전체 아키텍처
+
+```
+Controller
+    │
+    ▼
+DataExporter (Excel/CSV Export)
+    │
+    ├── ColumnMetaExtractor (어노테이션 파싱)
+    ├── ValueConverter (타입별 변환)
+    └── CellStyleFactory (스타일 생성)
+```
+
+### 4.2 모듈 구조
+
+`infrastructure` 모듈에 배치
+
+```
+modules/infrastructure/
+└── src/main/kotlin/io/glory/infrastructure/export/
+    ├── annotation/
+    │   ├── ExportColumn.kt
+    │   ├── ExportSheet.kt
+    │   ├── ExportCellStyle.kt
+    │   ├── ExportColor.kt
+    │   ├── ExportAlignment.kt
+    │   └── OverflowStrategy.kt
+    ├── DataExporter.kt              # Export 공통 인터페이스
+    ├── excel/
+    │   ├── ExcelExporter.kt
+    │   └── CellStyleFactory.kt
+    ├── csv/
+    │   └── CsvExporter.kt
+    ├── ColumnMetaExtractor.kt
+    └── ValueConverter.kt
+```
+
+> **Note**: 어노테이션명 `Export*`로 통일 (Excel/CSV 공용)
+
+**의존성**: `bootstrap` → `application` → `infrastructure` → `common`
+
+### 4.3 처리 흐름
+
+**동기 처리 (50만 건 미만)**:
+
+```
+1. Controller → DTO 리스트 + OutputStream 전달
+2. SXSSF Workbook 생성 (윈도우: 500행)
+3. @ExportColumn 어노테이션 정보 추출
+4. 헤더 행 생성 (스타일 적용)
+5. 데이터 행 순차 생성 (타입 변환)
+6. OutputStream 출력 → dispose()
+```
+
+**대용량 처리 (청크 기반)**:
+
+```
+1. No-Offset Paging으로 1만 건씩 조회
+2. 청크 → 엑셀 쓰기 → entityManager.clear()
+3. 반복 → 완료 시 dispose()
+```
+
+---
+
+## 5. 어노테이션 스펙
+
+### 5.1 @ExportColumn
+
+컬럼별 출력 설정
+
+```kotlin
+@Target(AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ExportColumn(
+    val header: String,                                    // 헤더명 (필수)
+    val order: Int = 0,                                    // 컬럼 순서
+    val width: Int = -1,                                   // 컬럼 너비 (-1: 자동)
+    val format: String = "",                               // 셀 포맷 (예: "#,##0")
+    val headerStyle: ExportCellStyle = ExportCellStyle(),  // 헤더 스타일
+    val bodyStyle: ExportCellStyle = ExportCellStyle(),    // 바디 스타일
+)
+```
+
+### 5.2 @ExportSheet
+
+시트 레벨 설정
+
+```kotlin
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ExportSheet(
+    val name: String = "Sheet1",                 // 시트명
+    val freezeHeader: Boolean = true,            // 헤더 행 고정
+    val includeIndex: Boolean = false,           // 인덱스 컬럼 포함 (No.)
+    val indexHeader: String = "No.",             // 인덱스 헤더명
+    val indexWidth: Int = 6,                     // 인덱스 너비
+    val overflowStrategy: OverflowStrategy = OverflowStrategy.MULTI_SHEET,
+)
+```
+
+**인덱스 컬럼**: `includeIndex = true` → 첫 번째 컬럼(A열)에 1부터 행 번호 자동 추가
+
+### 5.3 @ExportCellStyle
+
+셀 스타일 설정
+
+```kotlin
+annotation class ExportCellStyle(
+    val bold: Boolean = false,
+    val italic: Boolean = false,
+    val fontSize: Short = -1,                              // -1: 기본값 11pt
+    val fontColor: ExportColor = ExportColor.BLACK,
+    val bgColor: ExportColor = ExportColor.NONE,
+    val alignment: ExportAlignment = ExportAlignment.LEFT,
+)
+```
+
+**기본값**:
+- `headerStyle`: 볼드, 회색 배경, 가운데 정렬 (미지정 시)
+- `bodyStyle`: 스타일 없음
+
+### 5.4 Enum
+
+**ExportColor**:
+
+```kotlin
+enum class ExportColor(val index: Short) {
+    NONE(-1), BLACK(...), WHITE(...),
+    // 그레이
+    GREY_25(...), GREY_40(...), GREY_50(...),
+    // 배경용
+    LIGHT_BLUE(...), LIGHT_GREEN(...), LIGHT_YELLOW(...), LIGHT_ORANGE(...),
+    // 글자용
+    RED(...), DARK_RED(...), BLUE(...), DARK_BLUE(...), GREEN(...), ORANGE(...),
+}
+```
+
+**ExportAlignment**:
+
+```kotlin
+enum class ExportAlignment { LEFT, CENTER, RIGHT }
+```
+
+**OverflowStrategy**:
+
+```kotlin
+enum class OverflowStrategy {
+    MULTI_SHEET,   // 여러 시트로 분할 (Sheet1, Sheet2, ...)
+    EXCEPTION,     // 예외 발생
+    CSV_FALLBACK,  // CSV 파일로 대체 출력
+}
+```
+
+> 엑셀 시트 최대: 1,048,576행. 초과 시 `OverflowStrategy`에 따라 처리
+
+---
+
+## 6. 타입 변환 규칙
+
+| Kotlin 타입 | 셀 타입 | 기본 포맷 |
+|-------------|--------|----------|
+| `String` | STRING | - |
+| `Int`, `Long` | NUMERIC | `#,##0` |
+| `Double`, `BigDecimal` | NUMERIC | `#,##0.00` |
+| `Boolean` | STRING | "Y" / "N" |
+| `LocalDate` | NUMERIC | `yyyy-MM-dd` |
+| `LocalDateTime` | NUMERIC | `yyyy-MM-dd HH:mm:ss` |
+| `Enum` | STRING | `name()` |
+| `null` | BLANK | - |
+
+---
+
+## 7. 사용 예시
+
+### 7.1 기본 사용법
+
+**DTO 정의**:
+
+```kotlin
+@ExportSheet(name = "주문목록", includeIndex = true)
+data class OrderExportDto(
+    @ExportColumn(header = "주문번호", order = 1, width = 15)
+    val orderNo: String,
+
+    @ExportColumn(header = "주문일시", order = 2, format = "yyyy-MM-dd HH:mm")
+    val orderedAt: LocalDateTime,
+
+    @ExportColumn(header = "고객명", order = 3)
+    val customerName: String,
+
+    @ExportColumn(
+        header = "금액",
+        order = 4,
+        format = "#,##0",
+        bodyStyle = ExportCellStyle(bold = true, bgColor = ExportColor.LIGHT_BLUE),
+    )
+    val amount: BigDecimal,
+
+    @ExportColumn(
+        header = "상태",
+        order = 5,
+        bodyStyle = ExportCellStyle(fontColor = ExportColor.RED),
+    )
+    val status: OrderStatus,
+)
+```
+
+**Controller**:
+
+```kotlin
+@GetMapping("/excel")
+fun downloadExcel(
+    @RequestParam startDate: LocalDate,
+    @RequestParam endDate: LocalDate,
+    response: HttpServletResponse,
+) {
+    val orders = orderService.findOrders(startDate, endDate)
+        .map { it.toExportDto() }
+
+    response.contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    response.setHeader("Content-Disposition", "attachment; filename=\"orders.xlsx\"")
+
+    excelExporter.export(orders, OrderExportDto::class, response.outputStream)
+}
+```
+
+### 7.2 대용량 처리 (청크 기반)
+
+`@QueryProjection` DTO를 직접 조회하여 변환 비용 제거
+
+```kotlin
+@GetMapping("/excel")
+fun downloadLargeExcel(condition: OrderSearchCondition, response: HttpServletResponse) {
+    response.contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    response.setHeader("Content-Disposition", "attachment; filename=\"orders.xlsx\"")
+
+    excelExporter.exportWithChunks(
+        clazz = OrderExportDto::class,
+        outputStream = response.outputStream,
+    ) { consumer ->
+        // @QueryProjection DTO 직접 조회 → 변환 없이 바로 Export
+        orderQueryRepository.fetchOrderDtosInChunks(condition, consumer)
+    }
+}
+```
+
+---
+
+## 8. 성능 및 제약사항
+
+### 8.1 성능 최적화
+
+| 항목 | 방안 | 효과 |
+|------|------|------|
+| @QueryProjection | DTO 직접 조회 | 변환 비용 제거, clear() 불필요 |
+| SXSSF 윈도우 | 500행만 메모리 유지 | 메모리 90%↓ |
+| No-Offset Paging | `id > lastId` 방식 | 페이징 성능↑ |
+| 청크 처리 | 1만 건 단위 반복 | 안정적 처리 |
+| 스타일 캐싱 | CellStyle 재사용 | 64K 제한 회피 |
+| 리플렉션 캐싱 | 메타 1회 추출 | CPU↓ |
+| 임시 파일 정리 | `dispose()` 호출 | 디스크 누수 방지 |
+
+**예상 리소스**:
+
+| 건수 | 메모리 | 시간 | 처리 |
+|------|--------|------|------|
+| 1만 | ~50MB | ~3초 | 동기 |
+| 10만 | ~100MB | ~30초 | 동기 |
+| 50만 | ~150MB | ~2분 | 동기/비동기 |
+| 100만 | ~200MB | ~5분 | 비동기 권장 |
+
+### 8.2 제약사항
+
+| 제약 | 설명 | 대응 |
+|------|------|------|
+| 행 제한 | xlsx 최대 1,048,576행 | `OverflowStrategy` |
+| 쓰기 전용 | 생성 후 수정 불가 | XSSF (소량) |
+| 임시 파일 | 디스크 필요 | /tmp 확보, dispose() |
+| 스타일 제한 | Workbook당 64K | 캐싱 필수 |
+| 동시 요청 | 리소스 부하 | 다운로드 수 제한 |
+| 타임아웃 | 대용량 시 끊김 | 비동기 + 링크 |
+
+---
+
+## 9. 개발 로드맵
+
+### 9.1 Phase 1-4
+
+#### Phase 1: Core
+
+기본 Excel/CSV Export
+
+| 작업 | 산출물 |
+|------|--------|
+| 어노테이션 | `ExportColumn.kt`, `ExportSheet.kt` |
+| 메타 추출 | `ColumnMetaExtractor.kt` |
+| 타입 변환 | `ValueConverter.kt` |
+| Excel/CSV | `ExcelExporter.kt`, `CsvExporter.kt` |
+
+**완료**: 1만 건 Export 정상 동작
+
+---
+
+#### Phase 2: Styling
+
+헤더/바디 스타일링 (Excel 전용)
+
+| 작업 | 산출물 |
+|------|--------|
+| 스타일 어노테이션 | `ExportCellStyle.kt` |
+| Enum | `ExportColor.kt`, `ExportAlignment.kt` |
+| 스타일 팩토리 | `CellStyleFactory.kt` |
+| 인덱스 컬럼 | `@ExportSheet.includeIndex` |
+
+**완료**: headerStyle/bodyStyle 분리 적용, 인덱스 동작
+
+---
+
+#### Phase 3: Large Data
+
+100만 건+ 처리
+
+| 작업 | 산출물 |
+|------|--------|
+| 청크 Export | `exportWithChunks()` |
+| QueryDSL | No-Offset Paging |
+| 최적화 | SXSSF 윈도우 튜닝 |
+
+**완료**: 100만 건 OOM 없이 처리, 힙 256MB 이내
+
+---
+
+#### Phase 4: Advanced
+
+엣지 케이스 처리
+
+| 작업 | 산출물 |
+|------|--------|
+| 행 초과 | `OverflowStrategy` |
+
+| 멀티시트 | 시트 자동 분할 |
+| 문서화 | README |
+
+**완료**: 100만 건+ 멀티시트 분할 Export
+
+---
+
+**우선순위**: Phase 1~4 모두 **필수**
+
+### 9.2 Backlog: 비동기 다운로드
+
+초대용량 비동기 처리 (다음 Scope)
+
+**처리 흐름**:
+
+```
+다운로드 요청 → DB 저장 (PENDING) → URL 즉시 응답
+                    ↓
+         비동기 Worker 파일 생성 (PROCESSING)
+                    ↓
+              S3 업로드 (COMPLETED)
+                    ↓
+              담당자 알림 전송
+```
+
+**주요 기능**:
+
+| 기능 | 설명 |
+|------|------|
+| 중복 방지 | 해시 기반 1회만 실행 |
+| 파일 보관 | 30일 보관 |
+| 삭제 스케줄러 | 만료 파일 일 1회 삭제 |
+| 상태 조회 | PENDING → PROCESSING → COMPLETED/FAILED |
+
+**DB 스키마**:
+
+```sql
+create table excel_export_jobs (
+    id              bigint primary key,
+    request_hash    varchar(64) not null,
+    status          varchar(20) not null,
+    file_url        varchar(500),
+    error_message   varchar(500),
+    created_at      timestamp not null,
+    completed_at    timestamp,
+    expires_at      timestamp not null,
+
+    constraint uk_excel_export_jobs_01 unique (request_hash, status)
+);
+```
+
+---
+
+## 부록
+
+### A. QueryDSL Repository
+
+#### A-1. @QueryProjection DTO 직접 조회 (권장)
+
+Entity 대신 DTO를 직접 조회하여 **변환 비용 제거 + 필요 컬럼만 SELECT**
+
+```kotlin
+// DTO 정의
+@ExportSheet(name = "주문목록")
+data class OrderExportDto @QueryProjection constructor(
+    @ExportColumn(header = "주문번호", order = 1)
+    val orderNo: String,
+    @ExportColumn(header = "주문일시", order = 2)
+    val orderedAt: LocalDateTime,
+    @ExportColumn(header = "고객명", order = 3)
+    val customerName: String,
+    @ExportColumn(header = "금액", order = 4, format = "#,##0")
+    val amount: BigDecimal,
+    @ExportColumn(header = "상태", order = 5)
+    val status: OrderStatus,
+) {
+    // No-Offset Paging용 ID (Export 컬럼 아님)
+    @Transient
+    var id: Long = 0L
+}
+```
+
+```kotlin
+@Repository
+class OrderQueryRepository(
+    private val queryFactory: JPAQueryFactory,
+) {
+
+    /**
+     * @QueryProjection DTO 직접 조회 (권장)
+     * - Entity 변환 없음 → 성능↑
+     * - 영속성 컨텍스트 미사용 → entityManager.clear() 불필요
+     */
+    fun fetchOrderDtosInChunks(
+        condition: OrderSearchCondition,
+        chunkSize: Int = 10_000,
+        consumer: (List<OrderExportDto>) -> Unit,
+    ) {
+        var lastId: Long? = null
+
+        while (true) {
+            val chunk = queryFactory
+                .select(
+                    QOrderExportDto(
+                        order.orderNo,
+                        order.orderedAt,
+                        order.customer.name,
+                        order.amount,
+                        order.status,
+                    )
+                )
+                .from(order)
+                .join(order.customer, customer)
+                .where(
+                    order.orderedAt.between(condition.startDate, condition.endDate),
+                    condition.status?.let { order.status.eq(it) },
+                    lastId?.let { order.id.gt(it) }
+                )
+                .orderBy(order.id.asc())
+                .limit(chunkSize.toLong())
+                .fetch()
+                .onEach { it.id = order.id }  // No-Offset용 ID 세팅
+
+            if (chunk.isEmpty()) break
+
+            consumer(chunk)
+            lastId = chunk.last().id
+            // entityManager.clear() 불필요 (DTO는 영속성 컨텍스트에 없음)
+        }
+    }
+}
+```
+
+#### A-2. Entity 조회 후 변환
+
+Entity 조회가 필요한 경우 (복잡한 연관관계, 지연로딩 등)
+
+```kotlin
+@Repository
+class OrderQueryRepository(
+    private val queryFactory: JPAQueryFactory,
+    private val entityManager: EntityManager,
+) {
+
+    fun fetchOrdersInChunks(
+        condition: OrderSearchCondition,
+        chunkSize: Int = 10_000,
+        consumer: (List<Order>) -> Unit,
+    ) {
+        var lastId: Long? = null
+
+        while (true) {
+            val chunk = queryFactory
+                .selectFrom(order)
+                .join(order.customer, customer).fetchJoin()
+                .where(
+                    order.orderedAt.between(condition.startDate, condition.endDate),
+                    order.status.eq(condition.status),
+                    lastId?.let { order.id.gt(it) }
+                )
+                .orderBy(order.id.asc())
+                .limit(chunkSize.toLong())
+                .fetch()
+
+            if (chunk.isEmpty()) break
+
+            consumer(chunk)
+            lastId = chunk.last().id
+            entityManager.clear()  // Entity는 clear 필요
+        }
+    }
+}
+```
+
+#### 비교
+
+| 항목 | @QueryProjection DTO | Entity 조회 |
+|------|---------------------|-------------|
+| 변환 비용 | 없음 | Entity → DTO 변환 필요 |
+| SELECT 컬럼 | 필요한 것만 | 전체 컬럼 |
+| entityManager.clear() | 불필요 | 필요 |
+| 사용 케이스 | 단순 조회/Export | 복잡한 연관관계 |
+
+### B. CellStyleFactory
+
+```kotlin
+class CellStyleFactory(private val workbook: SXSSFWorkbook) {
+
+    private val styleCache = mutableMapOf<String, CellStyle>()
+    private val fontCache = mutableMapOf<String, Font>()
+
+    fun getStyle(style: ExportCellStyle, format: String? = null): CellStyle {
+        val key = buildStyleKey(style, format)
+        return styleCache.getOrPut(key) {
+            workbook.createCellStyle().apply {
+                if (style.bgColor != ExportColor.NONE) {
+                    fillForegroundColor = style.bgColor.index
+                    fillPattern = FillPatternType.SOLID_FOREGROUND
+                }
+                if (style.bold || style.italic || style.fontSize > 0 || style.fontColor != ExportColor.BLACK) {
+                    setFont(getFont(style))
+                }
+                alignment = when (style.alignment) {
+                    ExportAlignment.LEFT -> HorizontalAlignment.LEFT
+                    ExportAlignment.CENTER -> HorizontalAlignment.CENTER
+                    ExportAlignment.RIGHT -> HorizontalAlignment.RIGHT
+                }
+                if (!format.isNullOrBlank()) {
+                    dataFormat = workbook.createDataFormat().getFormat(format)
+                }
+            }
+        }
+    }
+
+    fun getDefaultHeaderStyle(): CellStyle {
+        return getStyle(
+            ExportCellStyle(
+                bold = true,
+                bgColor = ExportColor.GREY_25,
+                alignment = ExportAlignment.CENTER,
+            )
+        )
+    }
+
+    private fun getFont(style: ExportCellStyle): Font {
+        val key = "font_${style.bold}_${style.italic}_${style.fontSize}_${style.fontColor}"
+        return fontCache.getOrPut(key) {
+            workbook.createFont().apply {
+                bold = style.bold
+                italic = style.italic
+                if (style.fontSize > 0) fontHeightInPoints = style.fontSize
+                if (style.fontColor != ExportColor.BLACK) color = style.fontColor.index
+            }
+        }
+    }
+
+    private fun buildStyleKey(style: ExportCellStyle, format: String?) =
+        "style_${style.bgColor}_${style.fontColor}_${style.bold}_${style.italic}_${style.fontSize}_${style.alignment}_$format"
+}
+```
+
+### C. ExcelExportService
+
+```kotlin
+@Service
+class ExcelExportService(
+    private val entityManager: EntityManager,
+) {
+
+    fun <T : Any> export(data: List<T>, clazz: KClass<T>, outputStream: OutputStream) {
+        createWorkbook(clazz, outputStream) { sheet, styleFactory, columnMetas ->
+            data.forEachIndexed { index, item ->
+                createDataRow(sheet, index + 1, item, columnMetas, styleFactory)
+            }
+        }
+    }
+
+    fun <T : Any> exportWithChunks(
+        clazz: KClass<T>,
+        outputStream: OutputStream,
+        chunkFetcher: (consumer: (List<T>) -> Unit) -> Unit,
+    ) {
+        createWorkbook(clazz, outputStream) { sheet, styleFactory, columnMetas ->
+            var rowIndex = 1
+            chunkFetcher { chunk ->
+                chunk.forEach { item ->
+                    createDataRow(sheet, rowIndex++, item, columnMetas, styleFactory)
+                }
+                entityManager.clear()
+            }
+        }
+    }
+
+    private fun <T : Any> createWorkbook(
+        clazz: KClass<T>,
+        outputStream: OutputStream,
+        dataWriter: (SXSSFSheet, CellStyleFactory, List<ColumnMeta>) -> Unit,
+    ) {
+        SXSSFWorkbook(500).use { workbook ->
+            val sheetMeta = extractSheetMeta(clazz)
+            val columnMetas = extractColumnMetas(clazz)
+            val styleFactory = CellStyleFactory(workbook)
+
+            val sheet = workbook.createSheet(sheetMeta.name)
+            createHeaderRow(sheet, columnMetas, styleFactory)
+
+            if (sheetMeta.freezeHeader) sheet.createFreezePane(0, 1)
+
+            dataWriter(sheet, styleFactory, columnMetas)
+            setColumnWidths(sheet, columnMetas)
+
+            workbook.write(outputStream)
+            workbook.dispose()
+        }
+    }
+}
+```
+
+---
+
+## 변경 이력
+
+| 버전 | 날짜 | 내용 |
+|------|------|------|
+| 1.0 | 2025-01-17 | 최초 작성 |
+| 1.1 | 2025-01-17 | 구조 개선, 문장 다듬기 |
+| 1.2 | 2025-01-17 | @QueryProjection DTO 직접 조회 패턴 추가 |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ kotlinx-coroutines = "1.10.2"
 kotlin-logging = "7.0.13"
 
 # Third-party (not managed by Spring BOM)
+poi = "5.5.1"
 querydsl = "7.1"
 redisson = "4.1.0"
 lz4 = "1.10.2"
@@ -64,6 +65,9 @@ jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api" 
 # Database (managed by Spring BOM)
 h2 = { module = "com.h2database:h2" }
 mysql = { module = "com.mysql:mysql-connector-j" }
+
+# Apache POI (Excel)
+poi-ooxml = { module = "org.apache.poi:poi-ooxml", version.ref = "poi" }
 
 # Cache
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine" }

--- a/modules/infrastructure/build.gradle.kts
+++ b/modules/infrastructure/build.gradle.kts
@@ -19,6 +19,9 @@ dependencies {
     // Cache (Caffeine, Redisson, LZ4)
     implementation(rootProject.libs.bundles.cache)
 
+    // Apache POI (Excel Export)
+    implementation(rootProject.libs.poi.ooxml)
+
     // RestClient (HTTP Client with tracing support)
     implementation(rootProject.libs.spring.boot.starter.restclient)
     implementation(rootProject.libs.spring.boot.starter.aspectj)

--- a/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/ColumnMeta.kt
+++ b/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/ColumnMeta.kt
@@ -1,0 +1,25 @@
+package io.glory.infrastructure.export
+
+import kotlin.reflect.KProperty1
+
+/**
+ * Export 컬럼 메타데이터
+ */
+data class ColumnMeta(
+    val header: String,
+    val order: Int,
+    val width: Int,
+    val format: String,
+    val property: KProperty1<*, *>,
+)
+
+/**
+ * Export 시트 메타데이터
+ */
+data class SheetMeta(
+    val name: String,
+    val freezeHeader: Boolean,
+    val includeIndex: Boolean,
+    val indexHeader: String,
+    val indexWidth: Int,
+)

--- a/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/ColumnMeta.kt
+++ b/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/ColumnMeta.kt
@@ -1,5 +1,6 @@
 package io.glory.infrastructure.export
 
+import io.glory.infrastructure.export.annotation.ExportCellStyle
 import kotlin.reflect.KProperty1
 
 /**
@@ -11,6 +12,8 @@ data class ColumnMeta(
     val width: Int,
     val format: String,
     val property: KProperty1<*, *>,
+    val headerStyle: ExportCellStyle,
+    val bodyStyle: ExportCellStyle,
 )
 
 /**

--- a/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/ColumnMetaExtractor.kt
+++ b/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/ColumnMetaExtractor.kt
@@ -1,0 +1,69 @@
+package io.glory.infrastructure.export
+
+import io.glory.infrastructure.export.annotation.ExportColumn
+import io.glory.infrastructure.export.annotation.ExportSheet
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
+
+/**
+ * 어노테이션에서 Export 메타데이터를 추출
+ */
+object ColumnMetaExtractor {
+
+    private val sheetMetaCache = ConcurrentHashMap<KClass<*>, SheetMeta>()
+    private val columnMetaCache = ConcurrentHashMap<KClass<*>, List<ColumnMeta>>()
+
+    /**
+     * 클래스에서 시트 메타데이터 추출
+     */
+    fun extractSheetMeta(clazz: KClass<*>): SheetMeta {
+        return sheetMetaCache.getOrPut(clazz) {
+            val annotation = clazz.findAnnotation<ExportSheet>()
+            SheetMeta(
+                name = annotation?.name ?: "Sheet1",
+                freezeHeader = annotation?.freezeHeader ?: true,
+                includeIndex = annotation?.includeIndex ?: false,
+                indexHeader = annotation?.indexHeader ?: "No.",
+                indexWidth = annotation?.indexWidth ?: 6,
+            )
+        }
+    }
+
+    /**
+     * 클래스에서 컬럼 메타데이터 목록 추출 (order 순 정렬)
+     */
+    fun extractColumnMetas(clazz: KClass<*>): List<ColumnMeta> {
+        return columnMetaCache.getOrPut(clazz) {
+            clazz.memberProperties
+                .mapNotNull { property -> createColumnMeta(property) }
+                .sortedBy { it.order }
+        }
+    }
+
+    private fun createColumnMeta(property: KProperty1<*, *>): ColumnMeta? {
+        val annotation = property.findAnnotation<ExportColumn>() ?: return null
+
+        // Java 클래스의 private 필드 접근 허용
+        property.isAccessible = true
+
+        return ColumnMeta(
+            header = annotation.header,
+            order = annotation.order,
+            width = annotation.width,
+            format = annotation.format,
+            property = property,
+        )
+    }
+
+    /**
+     * 캐시 초기화 (테스트용)
+     */
+    fun clearCache() {
+        sheetMetaCache.clear()
+        columnMetaCache.clear()
+    }
+}

--- a/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/ColumnMetaExtractor.kt
+++ b/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/ColumnMetaExtractor.kt
@@ -56,6 +56,8 @@ object ColumnMetaExtractor {
             width = annotation.width,
             format = annotation.format,
             property = property,
+            headerStyle = annotation.headerStyle,
+            bodyStyle = annotation.bodyStyle,
         )
     }
 

--- a/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/DataExporter.kt
+++ b/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/DataExporter.kt
@@ -1,0 +1,36 @@
+package io.glory.infrastructure.export
+
+import java.io.OutputStream
+import kotlin.reflect.KClass
+
+/**
+ * 데이터 Export 공통 인터페이스
+ */
+interface DataExporter {
+
+    /**
+     * 데이터 리스트를 Export
+     *
+     * @param data Export 대상 데이터
+     * @param clazz DTO 클래스 (어노테이션 추출용)
+     * @param outputStream 출력 스트림
+     */
+    fun <T : Any> export(
+        data: List<T>,
+        clazz: KClass<T>,
+        outputStream: OutputStream,
+    )
+
+    /**
+     * 청크 단위로 데이터를 Export (대용량)
+     *
+     * @param clazz DTO 클래스 (어노테이션 추출용)
+     * @param outputStream 출력 스트림
+     * @param chunkFetcher 청크 데이터 제공 함수
+     */
+    fun <T : Any> exportWithChunks(
+        clazz: KClass<T>,
+        outputStream: OutputStream,
+        chunkFetcher: (consumer: (List<T>) -> Unit) -> Unit,
+    )
+}

--- a/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/ValueConverter.kt
+++ b/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/ValueConverter.kt
@@ -1,0 +1,103 @@
+package io.glory.infrastructure.export
+
+import org.apache.poi.ss.usermodel.Cell
+import org.apache.poi.ss.usermodel.CellStyle
+import org.apache.poi.ss.usermodel.CellType
+import org.apache.poi.ss.usermodel.Workbook
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * 타입별 셀 값 변환기
+ */
+object ValueConverter {
+
+    private val defaultDateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+    private val defaultDateTimeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+    private val defaultTimeFormat = DateTimeFormatter.ofPattern("HH:mm:ss")
+
+    /**
+     * 값을 셀에 설정
+     *
+     * @param cell 대상 셀
+     * @param value 설정할 값
+     * @param format 포맷 문자열 (날짜/숫자용)
+     * @param workbook Workbook (DataFormat 생성용)
+     * @param baseStyle 기본 스타일 (포맷 적용 시 복사)
+     */
+    fun setCellValue(
+        cell: Cell,
+        value: Any?,
+        format: String,
+        workbook: Workbook,
+        baseStyle: CellStyle? = null,
+    ) {
+        when (value) {
+            null -> cell.setBlank()
+            is String -> cell.setCellValue(value)
+            is Boolean -> cell.setCellValue(if (value) "Y" else "N")
+            is Int -> setNumericValue(cell, value.toDouble(), format, workbook, baseStyle)
+            is Long -> setNumericValue(cell, value.toDouble(), format, workbook, baseStyle)
+            is Double -> setNumericValue(cell, value, format, workbook, baseStyle)
+            is Float -> setNumericValue(cell, value.toDouble(), format, workbook, baseStyle)
+            is BigDecimal -> setNumericValue(cell, value.toDouble(), format, workbook, baseStyle)
+            is LocalDate -> setDateValue(cell, value, format)
+            is LocalDateTime -> setDateTimeValue(cell, value, format)
+            is LocalTime -> setTimeValue(cell, value, format)
+            is ZonedDateTime -> setDateTimeValue(cell, value.toLocalDateTime(), format)
+            is Enum<*> -> cell.setCellValue(value.name)
+            else -> cell.setCellValue(value.toString())
+        }
+    }
+
+    private fun setNumericValue(
+        cell: Cell,
+        value: Double,
+        format: String,
+        workbook: Workbook,
+        baseStyle: CellStyle?,
+    ) {
+        cell.setCellValue(value)
+        if (format.isNotBlank()) {
+            val style = baseStyle?.let { workbook.createCellStyle().apply { cloneStyleFrom(it) } }
+                ?: workbook.createCellStyle()
+            style.dataFormat = workbook.createDataFormat().getFormat(format)
+            cell.cellStyle = style
+        }
+    }
+
+    private fun setDateValue(cell: Cell, value: LocalDate, format: String) {
+        val formatter = if (format.isNotBlank()) {
+            DateTimeFormatter.ofPattern(format)
+        } else {
+            defaultDateFormat
+        }
+        cell.setCellValue(value.format(formatter))
+    }
+
+    private fun setDateTimeValue(cell: Cell, value: LocalDateTime, format: String) {
+        val formatter = if (format.isNotBlank()) {
+            DateTimeFormatter.ofPattern(format)
+        } else {
+            defaultDateTimeFormat
+        }
+        cell.setCellValue(value.format(formatter))
+    }
+
+    private fun setTimeValue(cell: Cell, value: LocalTime, format: String) {
+        val formatter = if (format.isNotBlank()) {
+            DateTimeFormatter.ofPattern(format)
+        } else {
+            defaultTimeFormat
+        }
+        cell.setCellValue(value.format(formatter))
+    }
+
+    private fun Cell.setBlank() {
+        setCellType(CellType.BLANK)
+    }
+}

--- a/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/annotation/ExportAlignment.kt
+++ b/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/annotation/ExportAlignment.kt
@@ -1,0 +1,14 @@
+package io.glory.infrastructure.export.annotation
+
+import org.apache.poi.ss.usermodel.HorizontalAlignment
+
+/**
+ * Export 정렬 Enum
+ *
+ * POI HorizontalAlignment와 매핑
+ */
+enum class ExportAlignment(val poiAlignment: HorizontalAlignment) {
+    LEFT(HorizontalAlignment.LEFT),
+    CENTER(HorizontalAlignment.CENTER),
+    RIGHT(HorizontalAlignment.RIGHT),
+}

--- a/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/annotation/ExportBorder.kt
+++ b/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/annotation/ExportBorder.kt
@@ -1,0 +1,18 @@
+package io.glory.infrastructure.export.annotation
+
+import org.apache.poi.ss.usermodel.BorderStyle
+
+/**
+ * Export 테두리 스타일 Enum
+ *
+ * POI BorderStyle과 매핑
+ */
+enum class ExportBorder(val poiBorderStyle: BorderStyle) {
+    NONE(BorderStyle.NONE),
+    THIN(BorderStyle.THIN),
+    MEDIUM(BorderStyle.MEDIUM),
+    THICK(BorderStyle.THICK),
+    DASHED(BorderStyle.DASHED),
+    DOTTED(BorderStyle.DOTTED),
+    DOUBLE(BorderStyle.DOUBLE),
+}

--- a/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/annotation/ExportCellStyle.kt
+++ b/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/annotation/ExportCellStyle.kt
@@ -1,0 +1,26 @@
+package io.glory.infrastructure.export.annotation
+
+/**
+ * Export 셀 스타일 설정
+ *
+ * @property bold 굵은 글씨
+ * @property italic 기울임
+ * @property fontSize 글자 크기 (-1: 기본값 11pt)
+ * @property fontColor 글자 색상
+ * @property bgColor 배경 색상
+ * @property alignment 정렬
+ * @property border 테두리 스타일 (상하좌우 동일)
+ * @property borderColor 테두리 색상
+ */
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ExportCellStyle(
+    val bold: Boolean = false,
+    val italic: Boolean = false,
+    val fontSize: Short = -1,
+    val fontColor: ExportColor = ExportColor.BLACK,
+    val bgColor: ExportColor = ExportColor.NONE,
+    val alignment: ExportAlignment = ExportAlignment.LEFT,
+    val border: ExportBorder = ExportBorder.NONE,
+    val borderColor: ExportColor = ExportColor.BLACK,
+)

--- a/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/annotation/ExportColor.kt
+++ b/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/annotation/ExportColor.kt
@@ -1,0 +1,34 @@
+package io.glory.infrastructure.export.annotation
+
+import org.apache.poi.ss.usermodel.IndexedColors
+
+/**
+ * Export 색상 Enum
+ *
+ * POI IndexedColors와 매핑
+ */
+enum class ExportColor(val index: Short) {
+    // 기본
+    NONE(IndexedColors.AUTOMATIC.index),
+    BLACK(IndexedColors.BLACK.index),
+    WHITE(IndexedColors.WHITE.index),
+
+    // 그레이 계열 (배경용)
+    GREY_25(IndexedColors.GREY_25_PERCENT.index),
+    GREY_40(IndexedColors.GREY_40_PERCENT.index),
+    GREY_50(IndexedColors.GREY_50_PERCENT.index),
+
+    // 밝은 색상 (배경용)
+    LIGHT_BLUE(IndexedColors.PALE_BLUE.index),
+    LIGHT_GREEN(IndexedColors.LIGHT_GREEN.index),
+    LIGHT_YELLOW(IndexedColors.LIGHT_YELLOW.index),
+    LIGHT_ORANGE(IndexedColors.LIGHT_ORANGE.index),
+
+    // 진한 색상 (글자용)
+    RED(IndexedColors.RED.index),
+    DARK_RED(IndexedColors.DARK_RED.index),
+    BLUE(IndexedColors.BLUE.index),
+    DARK_BLUE(IndexedColors.DARK_BLUE.index),
+    GREEN(IndexedColors.GREEN.index),
+    ORANGE(IndexedColors.ORANGE.index),
+}

--- a/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/annotation/ExportColumn.kt
+++ b/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/annotation/ExportColumn.kt
@@ -7,6 +7,8 @@ package io.glory.infrastructure.export.annotation
  * @property order 컬럼 순서 (낮을수록 왼쪽)
  * @property width 컬럼 너비 (256 단위, -1: 자동)
  * @property format 셀 포맷 (예: "#,##0", "yyyy-MM-dd")
+ * @property headerStyle 헤더 셀 스타일 (미지정 시 기본 스타일 적용)
+ * @property bodyStyle 바디 셀 스타일
  */
 @Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)
@@ -15,4 +17,6 @@ annotation class ExportColumn(
     val order: Int = 0,
     val width: Int = -1,
     val format: String = "",
+    val headerStyle: ExportCellStyle = ExportCellStyle(),
+    val bodyStyle: ExportCellStyle = ExportCellStyle(),
 )

--- a/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/annotation/ExportColumn.kt
+++ b/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/annotation/ExportColumn.kt
@@ -1,0 +1,18 @@
+package io.glory.infrastructure.export.annotation
+
+/**
+ * 엑셀/CSV Export 시 컬럼 설정
+ *
+ * @property header 헤더명 (필수)
+ * @property order 컬럼 순서 (낮을수록 왼쪽)
+ * @property width 컬럼 너비 (256 단위, -1: 자동)
+ * @property format 셀 포맷 (예: "#,##0", "yyyy-MM-dd")
+ */
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ExportColumn(
+    val header: String,
+    val order: Int = 0,
+    val width: Int = -1,
+    val format: String = "",
+)

--- a/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/annotation/ExportSheet.kt
+++ b/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/annotation/ExportSheet.kt
@@ -1,0 +1,20 @@
+package io.glory.infrastructure.export.annotation
+
+/**
+ * 엑셀 시트 레벨 설정
+ *
+ * @property name 시트명
+ * @property freezeHeader 헤더 행 고정 여부
+ * @property includeIndex 인덱스 컬럼 포함 여부 (No.)
+ * @property indexHeader 인덱스 헤더명
+ * @property indexWidth 인덱스 컬럼 너비
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ExportSheet(
+    val name: String = "Sheet1",
+    val freezeHeader: Boolean = true,
+    val includeIndex: Boolean = false,
+    val indexHeader: String = "No.",
+    val indexWidth: Int = 6,
+)

--- a/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/csv/CsvExporter.kt
+++ b/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/csv/CsvExporter.kt
@@ -1,0 +1,194 @@
+package io.glory.infrastructure.export.csv
+
+import io.glory.infrastructure.export.ColumnMeta
+import io.glory.infrastructure.export.ColumnMetaExtractor
+import io.glory.infrastructure.export.DataExporter
+import io.glory.infrastructure.export.SheetMeta
+import org.springframework.stereotype.Component
+import java.io.BufferedWriter
+import java.io.OutputStream
+import java.io.OutputStreamWriter
+import java.math.BigDecimal
+import java.nio.charset.Charset
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+
+/**
+ * CSV Exporter
+ *
+ * - 스트리밍 방식으로 대용량 데이터 처리
+ * - Excel과 달리 행 제한 없음
+ */
+@Component
+class CsvExporter(
+    private val charset: Charset = Charsets.UTF_8,
+    private val delimiter: Char = DEFAULT_DELIMITER,
+    private val includeHeader: Boolean = true,
+) : DataExporter {
+
+    override fun <T : Any> export(
+        data: List<T>,
+        clazz: KClass<T>,
+        outputStream: OutputStream,
+    ) {
+        val columnMetas = ColumnMetaExtractor.extractColumnMetas(clazz)
+        val sheetMeta = ColumnMetaExtractor.extractSheetMeta(clazz)
+
+        BufferedWriter(OutputStreamWriter(outputStream, charset)).use { writer ->
+            if (includeHeader) {
+                writeHeader(writer, columnMetas, sheetMeta)
+            }
+
+            var rowIndex = 1
+            data.forEach { item ->
+                writeDataRow(writer, rowIndex++, item, columnMetas, sheetMeta)
+            }
+        }
+    }
+
+    override fun <T : Any> exportWithChunks(
+        clazz: KClass<T>,
+        outputStream: OutputStream,
+        chunkFetcher: (consumer: (List<T>) -> Unit) -> Unit,
+    ) {
+        val columnMetas = ColumnMetaExtractor.extractColumnMetas(clazz)
+        val sheetMeta = ColumnMetaExtractor.extractSheetMeta(clazz)
+
+        BufferedWriter(OutputStreamWriter(outputStream, charset)).use { writer ->
+            if (includeHeader) {
+                writeHeader(writer, columnMetas, sheetMeta)
+            }
+
+            var rowIndex = 1
+            chunkFetcher { chunk ->
+                chunk.forEach { item ->
+                    writeDataRow(writer, rowIndex++, item, columnMetas, sheetMeta)
+                }
+            }
+        }
+    }
+
+    private fun writeHeader(
+        writer: BufferedWriter,
+        columnMetas: List<ColumnMeta>,
+        sheetMeta: SheetMeta,
+    ) {
+        val headers = buildList {
+            if (sheetMeta.includeIndex) {
+                add(escapeCsvValue(sheetMeta.indexHeader))
+            }
+            columnMetas.forEach { meta ->
+                add(escapeCsvValue(meta.header))
+            }
+        }
+        writer.write(headers.joinToString(delimiter.toString()))
+        writer.newLine()
+    }
+
+    private fun <T : Any> writeDataRow(
+        writer: BufferedWriter,
+        rowIndex: Int,
+        item: T,
+        columnMetas: List<ColumnMeta>,
+        sheetMeta: SheetMeta,
+    ) {
+        val values = buildList {
+            if (sheetMeta.includeIndex) {
+                add(rowIndex.toString())
+            }
+            columnMetas.forEach { meta ->
+                @Suppress("UNCHECKED_CAST")
+                val property = meta.property as KProperty1<T, *>
+                val value = property.get(item)
+                add(escapeCsvValue(convertToString(value, meta.format)))
+            }
+        }
+        writer.write(values.joinToString(delimiter.toString()))
+        writer.newLine()
+    }
+
+    private fun convertToString(value: Any?, format: String): String {
+        return when (value) {
+            null -> ""
+            is String -> value
+            is Boolean -> if (value) "Y" else "N"
+            is Int, is Long, is Float, is Double, is BigDecimal -> {
+                if (format.isNotBlank()) {
+                    formatNumber(value as Number, format)
+                } else {
+                    value.toString()
+                }
+            }
+            is LocalDate -> formatDate(value, format)
+            is LocalDateTime -> formatDateTime(value, format)
+            is LocalTime -> formatTime(value, format)
+            is ZonedDateTime -> formatDateTime(value.toLocalDateTime(), format)
+            is Enum<*> -> value.name
+            else -> value.toString()
+        }
+    }
+
+    private fun formatNumber(value: Number, format: String): String {
+        // Excel 포맷을 간단히 처리 (예: #,##0 -> 천단위 콤마)
+        return when {
+            format.contains("#,##0") -> {
+                val decimalFormat = java.text.DecimalFormat(format.replace("#,##0", "#,##0"))
+                decimalFormat.format(value)
+            }
+            else -> value.toString()
+        }
+    }
+
+    private fun formatDate(value: LocalDate, format: String): String {
+        val formatter = if (format.isNotBlank()) {
+            DateTimeFormatter.ofPattern(format)
+        } else {
+            DEFAULT_DATE_FORMAT
+        }
+        return value.format(formatter)
+    }
+
+    private fun formatDateTime(value: LocalDateTime, format: String): String {
+        val formatter = if (format.isNotBlank()) {
+            DateTimeFormatter.ofPattern(format)
+        } else {
+            DEFAULT_DATETIME_FORMAT
+        }
+        return value.format(formatter)
+    }
+
+    private fun formatTime(value: LocalTime, format: String): String {
+        val formatter = if (format.isNotBlank()) {
+            DateTimeFormatter.ofPattern(format)
+        } else {
+            DEFAULT_TIME_FORMAT
+        }
+        return value.format(formatter)
+    }
+
+    /**
+     * CSV 값 이스케이프 처리
+     *
+     * - 쌍따옴표, 쉼표, 개행이 포함된 경우 쌍따옴표로 감싸기
+     * - 내부 쌍따옴표는 두 번 연속으로 이스케이프
+     */
+    private fun escapeCsvValue(value: String): String {
+        return if (value.contains('"') || value.contains(delimiter) || value.contains('\n') || value.contains('\r')) {
+            "\"${value.replace("\"", "\"\"")}\""
+        } else {
+            value
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_DELIMITER = ','
+        private val DEFAULT_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        private val DEFAULT_DATETIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        private val DEFAULT_TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss")
+    }
+}

--- a/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/excel/CellStyleFactory.kt
+++ b/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/excel/CellStyleFactory.kt
@@ -1,0 +1,138 @@
+package io.glory.infrastructure.export.excel
+
+import io.glory.infrastructure.export.annotation.ExportAlignment
+import io.glory.infrastructure.export.annotation.ExportBorder
+import io.glory.infrastructure.export.annotation.ExportCellStyle
+import io.glory.infrastructure.export.annotation.ExportColor
+import org.apache.poi.ss.usermodel.CellStyle
+import org.apache.poi.ss.usermodel.FillPatternType
+import org.apache.poi.ss.usermodel.Font
+import org.apache.poi.xssf.streaming.SXSSFWorkbook
+
+/**
+ * Excel CellStyle 팩토리
+ *
+ * - POI 64K CellStyle 제한 대응을 위한 스타일 캐싱
+ * - 동일 스타일은 재사용하여 메모리 효율화
+ */
+class CellStyleFactory(val workbook: SXSSFWorkbook) {
+
+    private val styleCache = mutableMapOf<String, CellStyle>()
+    private val fontCache = mutableMapOf<String, Font>()
+    private val dataFormat by lazy { workbook.createDataFormat() }
+
+    /**
+     * ExportCellStyle 어노테이션 기반 CellStyle 생성/조회
+     *
+     * @param style 스타일 어노테이션
+     * @param format 셀 포맷 (숫자/날짜)
+     * @return 캐싱된 또는 새로 생성된 CellStyle
+     */
+    fun getStyle(style: ExportCellStyle, format: String? = null): CellStyle {
+        val key = buildStyleKey(style, format)
+        return styleCache.getOrPut(key) {
+            createCellStyle(style, format)
+        }
+    }
+
+    /**
+     * 기본 헤더 스타일 생성
+     *
+     * - 굵은 글씨
+     * - 회색 배경
+     * - 가운데 정렬
+     */
+    fun getDefaultHeaderStyle(): CellStyle {
+        return getStyle(DEFAULT_HEADER_STYLE)
+    }
+
+    /**
+     * 커스텀 헤더 스타일이 기본 스타일인지 확인
+     */
+    fun isDefaultStyle(style: ExportCellStyle): Boolean {
+        return !style.bold &&
+            !style.italic &&
+            style.fontSize == (-1).toShort() &&
+            style.fontColor == ExportColor.BLACK &&
+            style.bgColor == ExportColor.NONE &&
+            style.alignment == ExportAlignment.LEFT &&
+            style.border == ExportBorder.NONE
+    }
+
+    private fun createCellStyle(style: ExportCellStyle, format: String?): CellStyle {
+        return workbook.createCellStyle().apply {
+            // 배경색
+            if (style.bgColor != ExportColor.NONE) {
+                fillForegroundColor = style.bgColor.index
+                fillPattern = FillPatternType.SOLID_FOREGROUND
+            }
+
+            // 폰트 스타일
+            if (needsFont(style)) {
+                setFont(getFont(style))
+            }
+
+            // 정렬
+            alignment = style.alignment.poiAlignment
+
+            // 테두리
+            if (style.border != ExportBorder.NONE) {
+                borderTop = style.border.poiBorderStyle
+                borderBottom = style.border.poiBorderStyle
+                borderLeft = style.border.poiBorderStyle
+                borderRight = style.border.poiBorderStyle
+
+                if (style.borderColor != ExportColor.BLACK) {
+                    topBorderColor = style.borderColor.index
+                    bottomBorderColor = style.borderColor.index
+                    leftBorderColor = style.borderColor.index
+                    rightBorderColor = style.borderColor.index
+                }
+            }
+
+            // 포맷
+            if (!format.isNullOrBlank()) {
+                dataFormat = this@CellStyleFactory.dataFormat.getFormat(format)
+            }
+        }
+    }
+
+    private fun needsFont(style: ExportCellStyle): Boolean {
+        return style.bold ||
+            style.italic ||
+            style.fontSize > 0 ||
+            style.fontColor != ExportColor.BLACK
+    }
+
+    private fun getFont(style: ExportCellStyle): Font {
+        val key = buildFontKey(style)
+        return fontCache.getOrPut(key) {
+            workbook.createFont().apply {
+                bold = style.bold
+                italic = style.italic
+                if (style.fontSize > 0) {
+                    fontHeightInPoints = style.fontSize
+                }
+                if (style.fontColor != ExportColor.BLACK) {
+                    color = style.fontColor.index
+                }
+            }
+        }
+    }
+
+    private fun buildStyleKey(style: ExportCellStyle, format: String?): String {
+        return "style_${style.bgColor}_${style.fontColor}_${style.bold}_${style.italic}_${style.fontSize}_${style.alignment}_${style.border}_${style.borderColor}_$format"
+    }
+
+    private fun buildFontKey(style: ExportCellStyle): String {
+        return "font_${style.bold}_${style.italic}_${style.fontSize}_${style.fontColor}"
+    }
+
+    companion object {
+        private val DEFAULT_HEADER_STYLE = ExportCellStyle(
+            bold = true,
+            bgColor = ExportColor.GREY_25,
+            alignment = ExportAlignment.CENTER,
+        )
+    }
+}

--- a/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/excel/ExcelExporter.kt
+++ b/modules/infrastructure/src/main/kotlin/io/glory/infrastructure/export/excel/ExcelExporter.kt
@@ -1,0 +1,175 @@
+package io.glory.infrastructure.export.excel
+
+import io.glory.infrastructure.export.ColumnMeta
+import io.glory.infrastructure.export.ColumnMetaExtractor
+import io.glory.infrastructure.export.DataExporter
+import io.glory.infrastructure.export.SheetMeta
+import io.glory.infrastructure.export.ValueConverter
+import org.apache.poi.ss.usermodel.BorderStyle
+import org.apache.poi.ss.usermodel.CellStyle
+import org.apache.poi.ss.usermodel.FillPatternType
+import org.apache.poi.ss.usermodel.HorizontalAlignment
+import org.apache.poi.ss.usermodel.IndexedColors
+import org.apache.poi.xssf.streaming.SXSSFSheet
+import org.apache.poi.xssf.streaming.SXSSFWorkbook
+import org.springframework.stereotype.Component
+import java.io.OutputStream
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+
+/**
+ * SXSSF 기반 Excel Exporter
+ *
+ * - Streaming 방식으로 대용량 데이터 처리
+ * - 메모리에 지정된 행 수만 유지 (기본 500행)
+ */
+@Component
+class ExcelExporter(
+    private val rowAccessWindowSize: Int = DEFAULT_ROW_ACCESS_WINDOW_SIZE,
+) : DataExporter {
+
+    override fun <T : Any> export(
+        data: List<T>,
+        clazz: KClass<T>,
+        outputStream: OutputStream,
+    ) {
+        createWorkbook(clazz, outputStream) { sheet, columnMetas, sheetMeta, workbook, headerStyle ->
+            var rowIndex = 1
+            data.forEach { item ->
+                createDataRow(sheet, rowIndex++, item, columnMetas, sheetMeta, workbook)
+            }
+        }
+    }
+
+    override fun <T : Any> exportWithChunks(
+        clazz: KClass<T>,
+        outputStream: OutputStream,
+        chunkFetcher: (consumer: (List<T>) -> Unit) -> Unit,
+    ) {
+        createWorkbook(clazz, outputStream) { sheet, columnMetas, sheetMeta, workbook, headerStyle ->
+            var rowIndex = 1
+            chunkFetcher { chunk ->
+                chunk.forEach { item ->
+                    createDataRow(sheet, rowIndex++, item, columnMetas, sheetMeta, workbook)
+                }
+            }
+        }
+    }
+
+    private fun <T : Any> createWorkbook(
+        clazz: KClass<T>,
+        outputStream: OutputStream,
+        dataWriter: (SXSSFSheet, List<ColumnMeta>, SheetMeta, SXSSFWorkbook, CellStyle) -> Unit,
+    ) {
+        val workbook = SXSSFWorkbook(rowAccessWindowSize)
+        try {
+            val sheetMeta = ColumnMetaExtractor.extractSheetMeta(clazz)
+            val columnMetas = ColumnMetaExtractor.extractColumnMetas(clazz)
+            val headerStyle = createHeaderStyle(workbook)
+
+            val sheet = workbook.createSheet(sheetMeta.name)
+            createHeaderRow(sheet, columnMetas, sheetMeta, headerStyle)
+
+            if (sheetMeta.freezeHeader) {
+                sheet.createFreezePane(0, 1)
+            }
+
+            dataWriter(sheet, columnMetas, sheetMeta, workbook, headerStyle)
+
+            setColumnWidths(sheet, columnMetas, sheetMeta)
+
+            workbook.write(outputStream)
+        } finally {
+            workbook.dispose()
+            workbook.close()
+        }
+    }
+
+    private fun createHeaderRow(
+        sheet: SXSSFSheet,
+        columnMetas: List<ColumnMeta>,
+        sheetMeta: SheetMeta,
+        headerStyle: CellStyle,
+    ) {
+        val row = sheet.createRow(0)
+        var colIndex = 0
+
+        if (sheetMeta.includeIndex) {
+            val cell = row.createCell(colIndex++)
+            cell.setCellValue(sheetMeta.indexHeader)
+            cell.cellStyle = headerStyle
+        }
+
+        columnMetas.forEach { meta ->
+            val cell = row.createCell(colIndex++)
+            cell.setCellValue(meta.header)
+            cell.cellStyle = headerStyle
+        }
+    }
+
+    private fun <T : Any> createDataRow(
+        sheet: SXSSFSheet,
+        rowIndex: Int,
+        item: T,
+        columnMetas: List<ColumnMeta>,
+        sheetMeta: SheetMeta,
+        workbook: SXSSFWorkbook,
+    ) {
+        val row = sheet.createRow(rowIndex)
+        var colIndex = 0
+
+        if (sheetMeta.includeIndex) {
+            val cell = row.createCell(colIndex++)
+            cell.setCellValue(rowIndex.toDouble())
+        }
+
+        columnMetas.forEach { meta ->
+            val cell = row.createCell(colIndex++)
+            @Suppress("UNCHECKED_CAST")
+            val property = meta.property as KProperty1<T, *>
+            val value = property.get(item)
+            ValueConverter.setCellValue(cell, value, meta.format, workbook)
+        }
+    }
+
+    private fun setColumnWidths(
+        sheet: SXSSFSheet,
+        columnMetas: List<ColumnMeta>,
+        sheetMeta: SheetMeta,
+    ) {
+        var colIndex = 0
+
+        if (sheetMeta.includeIndex) {
+            sheet.setColumnWidth(colIndex++, sheetMeta.indexWidth * COLUMN_WIDTH_UNIT)
+        }
+
+        columnMetas.forEach { meta ->
+            if (meta.width > 0) {
+                sheet.setColumnWidth(colIndex, meta.width * COLUMN_WIDTH_UNIT)
+            }
+            colIndex++
+        }
+    }
+
+    private fun createHeaderStyle(workbook: SXSSFWorkbook): CellStyle {
+        return workbook.createCellStyle().apply {
+            fillForegroundColor = IndexedColors.GREY_25_PERCENT.index
+            fillPattern = FillPatternType.SOLID_FOREGROUND
+            alignment = HorizontalAlignment.CENTER
+            borderTop = BorderStyle.THIN
+            borderBottom = BorderStyle.THIN
+            borderLeft = BorderStyle.THIN
+            borderRight = BorderStyle.THIN
+
+            val font = workbook.createFont().apply {
+                bold = true
+            }
+            setFont(font)
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_ROW_ACCESS_WINDOW_SIZE = 500
+        private const val COLUMN_WIDTH_UNIT = 256
+    }
+}

--- a/modules/infrastructure/src/test/java/io/glory/infrastructure/export/JavaExportDto.java
+++ b/modules/infrastructure/src/test/java/io/glory/infrastructure/export/JavaExportDto.java
@@ -1,0 +1,27 @@
+package io.glory.infrastructure.export;
+
+import io.glory.infrastructure.export.annotation.ExportColumn;
+import io.glory.infrastructure.export.annotation.ExportSheet;
+
+@ExportSheet(name = "자바DTO")
+public class JavaExportDto {
+
+    @ExportColumn(header = "이름", order = 1)
+    private String name;
+
+    @ExportColumn(header = "나이", order = 2)
+    private int age;
+
+    public JavaExportDto(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+}

--- a/modules/infrastructure/src/test/java/io/glory/infrastructure/export/JavaRecordDto.java
+++ b/modules/infrastructure/src/test/java/io/glory/infrastructure/export/JavaRecordDto.java
@@ -1,0 +1,20 @@
+package io.glory.infrastructure.export;
+
+import io.glory.infrastructure.export.annotation.ExportColumn;
+import io.glory.infrastructure.export.annotation.ExportSheet;
+
+@ExportSheet(name = "자바레코드")
+public record JavaRecordDto(
+    @ExportColumn(header = "상품명", order = 1)
+    String productName,
+
+    @ExportColumn(header = "가격", order = 2, format = "#,##0")
+    int price,
+
+    @ExportColumn(header = "재고", order = 3)
+    int stock,
+
+    @ExportColumn(header = "판매중", order = 4)
+    boolean onSale
+) {
+}

--- a/modules/infrastructure/src/test/java/io/glory/infrastructure/export/JavaStyledRecordDto.java
+++ b/modules/infrastructure/src/test/java/io/glory/infrastructure/export/JavaStyledRecordDto.java
@@ -1,0 +1,54 @@
+package io.glory.infrastructure.export;
+
+import io.glory.infrastructure.export.annotation.ExportAlignment;
+import io.glory.infrastructure.export.annotation.ExportBorder;
+import io.glory.infrastructure.export.annotation.ExportCellStyle;
+import io.glory.infrastructure.export.annotation.ExportColor;
+import io.glory.infrastructure.export.annotation.ExportColumn;
+import io.glory.infrastructure.export.annotation.ExportSheet;
+
+@ExportSheet(name = "스타일적용")
+public record JavaStyledRecordDto(
+    @ExportColumn(
+        header = "상품명",
+        order = 1,
+        headerStyle = @ExportCellStyle(
+            bold = true,
+            bgColor = ExportColor.LIGHT_BLUE,
+            alignment = ExportAlignment.CENTER
+        ),
+        bodyStyle = @ExportCellStyle(
+            fontColor = ExportColor.BLUE
+        )
+    )
+    String productName,
+
+    @ExportColumn(
+        header = "가격",
+        order = 2,
+        format = "#,##0",
+        headerStyle = @ExportCellStyle(
+            bold = true,
+            bgColor = ExportColor.LIGHT_GREEN,
+            alignment = ExportAlignment.CENTER,
+            border = ExportBorder.THIN
+        ),
+        bodyStyle = @ExportCellStyle(
+            alignment = ExportAlignment.RIGHT,
+            border = ExportBorder.THIN
+        )
+    )
+    int price,
+
+    @ExportColumn(
+        header = "상태",
+        order = 3,
+        headerStyle = @ExportCellStyle(
+            bold = true,
+            bgColor = ExportColor.LIGHT_YELLOW,
+            alignment = ExportAlignment.CENTER
+        )
+    )
+    String status
+) {
+}

--- a/modules/infrastructure/src/test/kotlin/io/glory/infrastructure/export/ColumnMetaExtractorTest.kt
+++ b/modules/infrastructure/src/test/kotlin/io/glory/infrastructure/export/ColumnMetaExtractorTest.kt
@@ -1,0 +1,125 @@
+package io.glory.infrastructure.export
+
+import io.glory.infrastructure.export.annotation.ExportColumn
+import io.glory.infrastructure.export.annotation.ExportSheet
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ColumnMetaExtractorTest {
+
+    @BeforeEach
+    fun setUp(): Unit {
+        ColumnMetaExtractor.clearCache()
+    }
+
+    @Test
+    fun `should extract sheet meta with defaults when no annotation`(): Unit {
+        // given
+        class NoAnnotationDto
+
+        // when
+        val result = ColumnMetaExtractor.extractSheetMeta(NoAnnotationDto::class)
+
+        // then
+        assertThat(result.name).isEqualTo("Sheet1")
+        assertThat(result.freezeHeader).isTrue()
+        assertThat(result.includeIndex).isFalse()
+    }
+
+    @Test
+    fun `should extract sheet meta from annotation`(): Unit {
+        // given
+        @ExportSheet(
+            name = "테스트시트",
+            freezeHeader = false,
+            includeIndex = true,
+            indexHeader = "번호",
+            indexWidth = 10,
+        )
+        class AnnotatedDto
+
+        // when
+        val result = ColumnMetaExtractor.extractSheetMeta(AnnotatedDto::class)
+
+        // then
+        assertThat(result.name).isEqualTo("테스트시트")
+        assertThat(result.freezeHeader).isFalse()
+        assertThat(result.includeIndex).isTrue()
+        assertThat(result.indexHeader).isEqualTo("번호")
+        assertThat(result.indexWidth).isEqualTo(10)
+    }
+
+    @Test
+    fun `should extract column metas sorted by order`(): Unit {
+        // given
+        data class TestDto(
+            @ExportColumn(header = "세번째", order = 3)
+            val third: String,
+            @ExportColumn(header = "첫번째", order = 1)
+            val first: String,
+            @ExportColumn(header = "두번째", order = 2)
+            val second: String,
+        )
+
+        // when
+        val result = ColumnMetaExtractor.extractColumnMetas(TestDto::class)
+
+        // then
+        assertThat(result).hasSize(3)
+        assertThat(result[0].header).isEqualTo("첫번째")
+        assertThat(result[1].header).isEqualTo("두번째")
+        assertThat(result[2].header).isEqualTo("세번째")
+    }
+
+    @Test
+    fun `should extract column meta with format and width`(): Unit {
+        // given
+        data class TestDto(
+            @ExportColumn(header = "금액", order = 1, width = 15, format = "#,##0")
+            val amount: Int,
+        )
+
+        // when
+        val result = ColumnMetaExtractor.extractColumnMetas(TestDto::class)
+
+        // then
+        assertThat(result).hasSize(1)
+        assertThat(result[0].header).isEqualTo("금액")
+        assertThat(result[0].width).isEqualTo(15)
+        assertThat(result[0].format).isEqualTo("#,##0")
+    }
+
+    @Test
+    fun `should ignore properties without ExportColumn annotation`(): Unit {
+        // given
+        data class TestDto(
+            @ExportColumn(header = "이름", order = 1)
+            val name: String,
+            val ignoredField: String,
+        )
+
+        // when
+        val result = ColumnMetaExtractor.extractColumnMetas(TestDto::class)
+
+        // then
+        assertThat(result).hasSize(1)
+        assertThat(result[0].header).isEqualTo("이름")
+    }
+
+    @Test
+    fun `should cache extracted metas`(): Unit {
+        // given
+        data class TestDto(
+            @ExportColumn(header = "이름", order = 1)
+            val name: String,
+        )
+
+        // when
+        val first = ColumnMetaExtractor.extractColumnMetas(TestDto::class)
+        val second = ColumnMetaExtractor.extractColumnMetas(TestDto::class)
+
+        // then
+        assertThat(first).isSameAs(second)
+    }
+}

--- a/modules/infrastructure/src/test/kotlin/io/glory/infrastructure/export/ValueConverterTest.kt
+++ b/modules/infrastructure/src/test/kotlin/io/glory/infrastructure/export/ValueConverterTest.kt
@@ -9,6 +9,8 @@ import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 
 class ValueConverterTest {
 
@@ -32,7 +34,7 @@ class ValueConverterTest {
         val cell = sheet.createRow(0).createCell(0)
 
         // when
-        ValueConverter.setCellValue(cell, "테스트", "", workbook)
+        ValueConverter.setCellValue(cell, "테스트", "")
 
         // then
         assertThat(cell.stringCellValue).isEqualTo("테스트")
@@ -47,8 +49,8 @@ class ValueConverterTest {
         val cellFalse = row.createCell(1)
 
         // when
-        ValueConverter.setCellValue(cellTrue, true, "", workbook)
-        ValueConverter.setCellValue(cellFalse, false, "", workbook)
+        ValueConverter.setCellValue(cellTrue, true, "")
+        ValueConverter.setCellValue(cellFalse, false, "")
 
         // then
         assertThat(cellTrue.stringCellValue).isEqualTo("Y")
@@ -66,10 +68,10 @@ class ValueConverterTest {
         val cellBigDecimal = row.createCell(3)
 
         // when
-        ValueConverter.setCellValue(cellInt, 100, "", workbook)
-        ValueConverter.setCellValue(cellLong, 200L, "", workbook)
-        ValueConverter.setCellValue(cellDouble, 300.5, "", workbook)
-        ValueConverter.setCellValue(cellBigDecimal, BigDecimal("400.75"), "", workbook)
+        ValueConverter.setCellValue(cellInt, 100, "")
+        ValueConverter.setCellValue(cellLong, 200L, "")
+        ValueConverter.setCellValue(cellDouble, 300.5, "")
+        ValueConverter.setCellValue(cellBigDecimal, BigDecimal("400.75"), "")
 
         // then
         assertThat(cellInt.numericCellValue).isEqualTo(100.0)
@@ -86,7 +88,7 @@ class ValueConverterTest {
         val date = LocalDate.of(2025, 1, 17)
 
         // when
-        ValueConverter.setCellValue(cell, date, "", workbook)
+        ValueConverter.setCellValue(cell, date, "")
 
         // then
         assertThat(cell.stringCellValue).isEqualTo("2025-01-17")
@@ -100,7 +102,7 @@ class ValueConverterTest {
         val date = LocalDate.of(2025, 1, 17)
 
         // when
-        ValueConverter.setCellValue(cell, date, "yyyy/MM/dd", workbook)
+        ValueConverter.setCellValue(cell, date, "yyyy/MM/dd")
 
         // then
         assertThat(cell.stringCellValue).isEqualTo("2025/01/17")
@@ -114,7 +116,7 @@ class ValueConverterTest {
         val dateTime = LocalDateTime.of(2025, 1, 17, 14, 30, 45)
 
         // when
-        ValueConverter.setCellValue(cell, dateTime, "", workbook)
+        ValueConverter.setCellValue(cell, dateTime, "")
 
         // then
         assertThat(cell.stringCellValue).isEqualTo("2025-01-17 14:30:45")
@@ -128,7 +130,7 @@ class ValueConverterTest {
         val time = LocalTime.of(14, 30, 45)
 
         // when
-        ValueConverter.setCellValue(cell, time, "", workbook)
+        ValueConverter.setCellValue(cell, time, "")
 
         // then
         assertThat(cell.stringCellValue).isEqualTo("14:30:45")
@@ -141,7 +143,7 @@ class ValueConverterTest {
         val cell = sheet.createRow(0).createCell(0)
 
         // when
-        ValueConverter.setCellValue(cell, TestStatus.ACTIVE, "", workbook)
+        ValueConverter.setCellValue(cell, TestStatus.ACTIVE, "")
 
         // then
         assertThat(cell.stringCellValue).isEqualTo("ACTIVE")
@@ -154,10 +156,52 @@ class ValueConverterTest {
         val cell = sheet.createRow(0).createCell(0)
 
         // when
-        ValueConverter.setCellValue(cell, null, "", workbook)
+        ValueConverter.setCellValue(cell, null, "")
 
         // then
         assertThat(cell.cellType.name).isEqualTo("BLANK")
+    }
+
+    @Test
+    fun `should set ZonedDateTime with default ISO format`(): Unit {
+        // given
+        val sheet = workbook.createSheet()
+        val cell = sheet.createRow(0).createCell(0)
+        val zonedDateTime = ZonedDateTime.of(2025, 1, 17, 14, 30, 45, 0, ZoneId.of("Asia/Seoul"))
+
+        // when
+        ValueConverter.setCellValue(cell, zonedDateTime, "")
+
+        // then
+        assertThat(cell.stringCellValue).isEqualTo("2025-01-17T14:30:45+09:00[Asia/Seoul]")
+    }
+
+    @Test
+    fun `should set ZonedDateTime with custom format`(): Unit {
+        // given
+        val sheet = workbook.createSheet()
+        val cell = sheet.createRow(0).createCell(0)
+        val zonedDateTime = ZonedDateTime.of(2025, 1, 17, 14, 30, 45, 0, ZoneId.of("Asia/Seoul"))
+
+        // when
+        ValueConverter.setCellValue(cell, zonedDateTime, "yyyy-MM-dd HH:mm:ss")
+
+        // then
+        assertThat(cell.stringCellValue).isEqualTo("2025-01-17 14:30:45")
+    }
+
+    @Test
+    fun `should apply style when provided`(): Unit {
+        // given
+        val sheet = workbook.createSheet()
+        val cell = sheet.createRow(0).createCell(0)
+        val style = workbook.createCellStyle()
+
+        // when
+        ValueConverter.setCellValue(cell, "테스트", "", style)
+
+        // then
+        assertThat(cell.cellStyle).isSameAs(style)
     }
 
     private enum class TestStatus {

--- a/modules/infrastructure/src/test/kotlin/io/glory/infrastructure/export/ValueConverterTest.kt
+++ b/modules/infrastructure/src/test/kotlin/io/glory/infrastructure/export/ValueConverterTest.kt
@@ -1,0 +1,166 @@
+package io.glory.infrastructure.export
+
+import org.apache.poi.xssf.streaming.SXSSFWorkbook
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class ValueConverterTest {
+
+    private lateinit var workbook: SXSSFWorkbook
+
+    @BeforeEach
+    fun setUp(): Unit {
+        workbook = SXSSFWorkbook()
+    }
+
+    @AfterEach
+    fun tearDown(): Unit {
+        workbook.dispose()
+        workbook.close()
+    }
+
+    @Test
+    fun `should set string value`(): Unit {
+        // given
+        val sheet = workbook.createSheet()
+        val cell = sheet.createRow(0).createCell(0)
+
+        // when
+        ValueConverter.setCellValue(cell, "테스트", "", workbook)
+
+        // then
+        assertThat(cell.stringCellValue).isEqualTo("테스트")
+    }
+
+    @Test
+    fun `should set boolean as Y or N`(): Unit {
+        // given
+        val sheet = workbook.createSheet()
+        val row = sheet.createRow(0)
+        val cellTrue = row.createCell(0)
+        val cellFalse = row.createCell(1)
+
+        // when
+        ValueConverter.setCellValue(cellTrue, true, "", workbook)
+        ValueConverter.setCellValue(cellFalse, false, "", workbook)
+
+        // then
+        assertThat(cellTrue.stringCellValue).isEqualTo("Y")
+        assertThat(cellFalse.stringCellValue).isEqualTo("N")
+    }
+
+    @Test
+    fun `should set numeric values`(): Unit {
+        // given
+        val sheet = workbook.createSheet()
+        val row = sheet.createRow(0)
+        val cellInt = row.createCell(0)
+        val cellLong = row.createCell(1)
+        val cellDouble = row.createCell(2)
+        val cellBigDecimal = row.createCell(3)
+
+        // when
+        ValueConverter.setCellValue(cellInt, 100, "", workbook)
+        ValueConverter.setCellValue(cellLong, 200L, "", workbook)
+        ValueConverter.setCellValue(cellDouble, 300.5, "", workbook)
+        ValueConverter.setCellValue(cellBigDecimal, BigDecimal("400.75"), "", workbook)
+
+        // then
+        assertThat(cellInt.numericCellValue).isEqualTo(100.0)
+        assertThat(cellLong.numericCellValue).isEqualTo(200.0)
+        assertThat(cellDouble.numericCellValue).isEqualTo(300.5)
+        assertThat(cellBigDecimal.numericCellValue).isEqualTo(400.75)
+    }
+
+    @Test
+    fun `should set LocalDate with default format`(): Unit {
+        // given
+        val sheet = workbook.createSheet()
+        val cell = sheet.createRow(0).createCell(0)
+        val date = LocalDate.of(2025, 1, 17)
+
+        // when
+        ValueConverter.setCellValue(cell, date, "", workbook)
+
+        // then
+        assertThat(cell.stringCellValue).isEqualTo("2025-01-17")
+    }
+
+    @Test
+    fun `should set LocalDate with custom format`(): Unit {
+        // given
+        val sheet = workbook.createSheet()
+        val cell = sheet.createRow(0).createCell(0)
+        val date = LocalDate.of(2025, 1, 17)
+
+        // when
+        ValueConverter.setCellValue(cell, date, "yyyy/MM/dd", workbook)
+
+        // then
+        assertThat(cell.stringCellValue).isEqualTo("2025/01/17")
+    }
+
+    @Test
+    fun `should set LocalDateTime with default format`(): Unit {
+        // given
+        val sheet = workbook.createSheet()
+        val cell = sheet.createRow(0).createCell(0)
+        val dateTime = LocalDateTime.of(2025, 1, 17, 14, 30, 45)
+
+        // when
+        ValueConverter.setCellValue(cell, dateTime, "", workbook)
+
+        // then
+        assertThat(cell.stringCellValue).isEqualTo("2025-01-17 14:30:45")
+    }
+
+    @Test
+    fun `should set LocalTime with default format`(): Unit {
+        // given
+        val sheet = workbook.createSheet()
+        val cell = sheet.createRow(0).createCell(0)
+        val time = LocalTime.of(14, 30, 45)
+
+        // when
+        ValueConverter.setCellValue(cell, time, "", workbook)
+
+        // then
+        assertThat(cell.stringCellValue).isEqualTo("14:30:45")
+    }
+
+    @Test
+    fun `should set enum as name`(): Unit {
+        // given
+        val sheet = workbook.createSheet()
+        val cell = sheet.createRow(0).createCell(0)
+
+        // when
+        ValueConverter.setCellValue(cell, TestStatus.ACTIVE, "", workbook)
+
+        // then
+        assertThat(cell.stringCellValue).isEqualTo("ACTIVE")
+    }
+
+    @Test
+    fun `should set null as blank`(): Unit {
+        // given
+        val sheet = workbook.createSheet()
+        val cell = sheet.createRow(0).createCell(0)
+
+        // when
+        ValueConverter.setCellValue(cell, null, "", workbook)
+
+        // then
+        assertThat(cell.cellType.name).isEqualTo("BLANK")
+    }
+
+    private enum class TestStatus {
+        ACTIVE, INACTIVE
+    }
+}

--- a/modules/infrastructure/src/test/kotlin/io/glory/infrastructure/export/csv/CsvExporterTest.kt
+++ b/modules/infrastructure/src/test/kotlin/io/glory/infrastructure/export/csv/CsvExporterTest.kt
@@ -1,0 +1,267 @@
+package io.glory.infrastructure.export.csv
+
+import io.glory.infrastructure.export.ColumnMetaExtractor
+import io.glory.infrastructure.export.annotation.ExportColumn
+import io.glory.infrastructure.export.annotation.ExportSheet
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class CsvExporterTest {
+
+    private lateinit var exporter: CsvExporter
+
+    @BeforeEach
+    fun setUp(): Unit {
+        exporter = CsvExporter()
+        ColumnMetaExtractor.clearCache()
+    }
+
+    @Test
+    fun `should export simple data to csv`(): Unit {
+        // given
+        val data = listOf(
+            SimpleDto(name = "홍길동", age = 30),
+            SimpleDto(name = "김철수", age = 25),
+        )
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, SimpleDto::class, outputStream)
+
+        // then
+        val lines = outputStream.toString(Charsets.UTF_8).lines().filter { it.isNotBlank() }
+        assertThat(lines).hasSize(3)
+        assertThat(lines[0]).isEqualTo("이름,나이")
+        assertThat(lines[1]).isEqualTo("홍길동,30")
+        assertThat(lines[2]).isEqualTo("김철수,25")
+    }
+
+    @Test
+    fun `should export with index column when includeIndex is true`(): Unit {
+        // given
+        val data = listOf(
+            IndexedDto(name = "첫번째"),
+            IndexedDto(name = "두번째"),
+        )
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, IndexedDto::class, outputStream)
+
+        // then
+        val lines = outputStream.toString(Charsets.UTF_8).lines().filter { it.isNotBlank() }
+        assertThat(lines).hasSize(3)
+        assertThat(lines[0]).isEqualTo("No.,이름")
+        assertThat(lines[1]).isEqualTo("1,첫번째")
+        assertThat(lines[2]).isEqualTo("2,두번째")
+    }
+
+    @Test
+    fun `should export various types correctly`(): Unit {
+        // given
+        val data = listOf(
+            VariousTypesDto(
+                text = "텍스트",
+                number = 1000,
+                decimal = BigDecimal("1234.56"),
+                date = LocalDate.of(2025, 1, 17),
+                dateTime = LocalDateTime.of(2025, 1, 17, 14, 30),
+                flag = true,
+                status = OrderStatus.COMPLETED,
+            )
+        )
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, VariousTypesDto::class, outputStream)
+
+        // then
+        val lines = outputStream.toString(Charsets.UTF_8).lines().filter { it.isNotBlank() }
+        assertThat(lines).hasSize(2)
+        assertThat(lines[0]).isEqualTo("텍스트,숫자,소수,날짜,일시,플래그,상태")
+        assertThat(lines[1]).isEqualTo("텍스트,1000,1234.56,2025-01-17,2025-01-17 14:30,Y,COMPLETED")
+    }
+
+    @Test
+    fun `should export with chunks`(): Unit {
+        // given
+        val allData = (1..100).map { SimpleDto(name = "이름$it", age = it) }
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.exportWithChunks(SimpleDto::class, outputStream) { consumer ->
+            allData.chunked(30).forEach { chunk ->
+                consumer(chunk)
+            }
+        }
+
+        // then
+        val lines = outputStream.toString(Charsets.UTF_8).lines().filter { it.isNotBlank() }
+        assertThat(lines).hasSize(101) // header + 100 data rows
+        assertThat(lines[0]).isEqualTo("이름,나이")
+        assertThat(lines[1]).isEqualTo("이름1,1")
+        assertThat(lines[100]).isEqualTo("이름100,100")
+    }
+
+    @Test
+    fun `should sort columns by order`(): Unit {
+        // given
+        val data = listOf(OrderedDto(third = "C", first = "A", second = "B"))
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, OrderedDto::class, outputStream)
+
+        // then
+        val lines = outputStream.toString(Charsets.UTF_8).lines().filter { it.isNotBlank() }
+        assertThat(lines[0]).isEqualTo("첫번째,두번째,세번째")
+        assertThat(lines[1]).isEqualTo("A,B,C")
+    }
+
+    @Test
+    fun `should escape values containing comma`(): Unit {
+        // given
+        val data = listOf(SimpleDto(name = "홍길동,김철수", age = 30))
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, SimpleDto::class, outputStream)
+
+        // then
+        val lines = outputStream.toString(Charsets.UTF_8).lines().filter { it.isNotBlank() }
+        assertThat(lines[1]).isEqualTo("\"홍길동,김철수\",30")
+    }
+
+    @Test
+    fun `should escape values containing double quote`(): Unit {
+        // given
+        val data = listOf(SimpleDto(name = "홍\"길\"동", age = 30))
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, SimpleDto::class, outputStream)
+
+        // then
+        val lines = outputStream.toString(Charsets.UTF_8).lines().filter { it.isNotBlank() }
+        assertThat(lines[1]).isEqualTo("\"홍\"\"길\"\"동\",30")
+    }
+
+    @Test
+    fun `should escape values containing newline`(): Unit {
+        // given
+        val data = listOf(SimpleDto(name = "홍길동\n김철수", age = 30))
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, SimpleDto::class, outputStream)
+
+        // then
+        val content = outputStream.toString(Charsets.UTF_8)
+        assertThat(content).contains("\"홍길동\n김철수\"")
+    }
+
+    @Test
+    fun `should handle null values`(): Unit {
+        // given
+        val data = listOf(NullableDto(name = null, value = "test"))
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, NullableDto::class, outputStream)
+
+        // then
+        val lines = outputStream.toString(Charsets.UTF_8).lines().filter { it.isNotBlank() }
+        assertThat(lines[1]).isEqualTo(",test")
+    }
+
+    @Test
+    fun `should format number with custom format`(): Unit {
+        // given
+        val data = listOf(FormattedNumberDto(amount = 1234567))
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, FormattedNumberDto::class, outputStream)
+
+        // then
+        val lines = outputStream.toString(Charsets.UTF_8).lines().filter { it.isNotBlank() }
+        assertThat(lines[1]).isEqualTo("\"1,234,567\"")
+    }
+
+    @Test
+    fun `should export empty data with header only`(): Unit {
+        // given
+        val data = emptyList<SimpleDto>()
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, SimpleDto::class, outputStream)
+
+        // then
+        val lines = outputStream.toString(Charsets.UTF_8).lines().filter { it.isNotBlank() }
+        assertThat(lines).hasSize(1)
+        assertThat(lines[0]).isEqualTo("이름,나이")
+    }
+
+    // Test DTOs
+
+    data class SimpleDto(
+        @ExportColumn(header = "이름", order = 1)
+        val name: String,
+        @ExportColumn(header = "나이", order = 2)
+        val age: Int,
+    )
+
+    @ExportSheet(includeIndex = true)
+    data class IndexedDto(
+        @ExportColumn(header = "이름", order = 1)
+        val name: String,
+    )
+
+    data class VariousTypesDto(
+        @ExportColumn(header = "텍스트", order = 1)
+        val text: String,
+        @ExportColumn(header = "숫자", order = 2)
+        val number: Int,
+        @ExportColumn(header = "소수", order = 3)
+        val decimal: BigDecimal,
+        @ExportColumn(header = "날짜", order = 4)
+        val date: LocalDate,
+        @ExportColumn(header = "일시", order = 5, format = "yyyy-MM-dd HH:mm")
+        val dateTime: LocalDateTime,
+        @ExportColumn(header = "플래그", order = 6)
+        val flag: Boolean,
+        @ExportColumn(header = "상태", order = 7)
+        val status: OrderStatus,
+    )
+
+    data class OrderedDto(
+        @ExportColumn(header = "세번째", order = 3)
+        val third: String,
+        @ExportColumn(header = "첫번째", order = 1)
+        val first: String,
+        @ExportColumn(header = "두번째", order = 2)
+        val second: String,
+    )
+
+    data class NullableDto(
+        @ExportColumn(header = "이름", order = 1)
+        val name: String?,
+        @ExportColumn(header = "값", order = 2)
+        val value: String,
+    )
+
+    data class FormattedNumberDto(
+        @ExportColumn(header = "금액", order = 1, format = "#,##0")
+        val amount: Int,
+    )
+
+    enum class OrderStatus {
+        PENDING, COMPLETED, CANCELLED
+    }
+}

--- a/modules/infrastructure/src/test/kotlin/io/glory/infrastructure/export/excel/CellStyleFactoryTest.kt
+++ b/modules/infrastructure/src/test/kotlin/io/glory/infrastructure/export/excel/CellStyleFactoryTest.kt
@@ -1,0 +1,241 @@
+package io.glory.infrastructure.export.excel
+
+import io.glory.infrastructure.export.annotation.ExportAlignment
+import io.glory.infrastructure.export.annotation.ExportBorder
+import io.glory.infrastructure.export.annotation.ExportCellStyle
+import io.glory.infrastructure.export.annotation.ExportColor
+import org.apache.poi.ss.usermodel.BorderStyle
+import org.apache.poi.ss.usermodel.FillPatternType
+import org.apache.poi.ss.usermodel.HorizontalAlignment
+import org.apache.poi.xssf.streaming.SXSSFWorkbook
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CellStyleFactoryTest {
+
+    private lateinit var workbook: SXSSFWorkbook
+    private lateinit var factory: CellStyleFactory
+
+    @BeforeEach
+    fun setUp(): Unit {
+        workbook = SXSSFWorkbook()
+        factory = CellStyleFactory(workbook)
+    }
+
+    @AfterEach
+    fun tearDown(): Unit {
+        workbook.dispose()
+        workbook.close()
+    }
+
+    @Test
+    fun `should create default header style with bold grey background and center alignment`(): Unit {
+        // when
+        val style = factory.getDefaultHeaderStyle()
+
+        // then
+        assertThat(style.fillForegroundColor).isEqualTo(ExportColor.GREY_25.index)
+        assertThat(style.fillPattern).isEqualTo(FillPatternType.SOLID_FOREGROUND)
+        assertThat(style.alignment).isEqualTo(HorizontalAlignment.CENTER)
+    }
+
+    @Test
+    fun `should create style with custom background color`(): Unit {
+        // given
+        val customStyle = ExportCellStyle(bgColor = ExportColor.LIGHT_BLUE)
+
+        // when
+        val style = factory.getStyle(customStyle)
+
+        // then
+        assertThat(style.fillForegroundColor).isEqualTo(ExportColor.LIGHT_BLUE.index)
+        assertThat(style.fillPattern).isEqualTo(FillPatternType.SOLID_FOREGROUND)
+    }
+
+    @Test
+    fun `should create style with custom alignment`(): Unit {
+        // given
+        val rightAligned = ExportCellStyle(alignment = ExportAlignment.RIGHT)
+
+        // when
+        val style = factory.getStyle(rightAligned)
+
+        // then
+        assertThat(style.alignment).isEqualTo(HorizontalAlignment.RIGHT)
+    }
+
+    @Test
+    fun `should create style with bold font`(): Unit {
+        // given
+        val boldStyle = ExportCellStyle(bold = true)
+
+        // when
+        val style = factory.getStyle(boldStyle)
+
+        // then
+        val font = workbook.getFontAt(style.fontIndex)
+        assertThat(font.bold).isTrue
+    }
+
+    @Test
+    fun `should create style with custom font color`(): Unit {
+        // given
+        val redFontStyle = ExportCellStyle(fontColor = ExportColor.RED)
+
+        // when
+        val style = factory.getStyle(redFontStyle)
+
+        // then
+        val font = workbook.getFontAt(style.fontIndex)
+        assertThat(font.color).isEqualTo(ExportColor.RED.index)
+    }
+
+    @Test
+    fun `should cache and reuse same style`(): Unit {
+        // given
+        val customStyle = ExportCellStyle(bold = true, bgColor = ExportColor.LIGHT_GREEN)
+
+        // when
+        val style1 = factory.getStyle(customStyle)
+        val style2 = factory.getStyle(customStyle)
+
+        // then
+        assertThat(style1).isSameAs(style2)
+    }
+
+    @Test
+    fun `should create different styles for different configurations`(): Unit {
+        // given
+        val style1Config = ExportCellStyle(bold = true)
+        val style2Config = ExportCellStyle(italic = true)
+
+        // when
+        val style1 = factory.getStyle(style1Config)
+        val style2 = factory.getStyle(style2Config)
+
+        // then
+        assertThat(style1).isNotSameAs(style2)
+    }
+
+    @Test
+    fun `should include format in style key`(): Unit {
+        // given
+        val baseStyle = ExportCellStyle()
+
+        // when
+        val styleWithFormat1 = factory.getStyle(baseStyle, "#,##0")
+        val styleWithFormat2 = factory.getStyle(baseStyle, "yyyy-MM-dd")
+
+        // then
+        assertThat(styleWithFormat1).isNotSameAs(styleWithFormat2)
+    }
+
+    @Test
+    fun `isDefaultStyle should return true for default style`(): Unit {
+        // given
+        val defaultStyle = ExportCellStyle()
+
+        // when & then
+        assertThat(factory.isDefaultStyle(defaultStyle)).isTrue
+    }
+
+    @Test
+    fun `isDefaultStyle should return false for customized style`(): Unit {
+        // given
+        val customStyles = listOf(
+            ExportCellStyle(bold = true),
+            ExportCellStyle(italic = true),
+            ExportCellStyle(fontSize = 14),
+            ExportCellStyle(fontColor = ExportColor.RED),
+            ExportCellStyle(bgColor = ExportColor.LIGHT_BLUE),
+            ExportCellStyle(alignment = ExportAlignment.CENTER),
+            ExportCellStyle(border = ExportBorder.THIN),
+        )
+
+        // when & then
+        customStyles.forEach { style ->
+            assertThat(factory.isDefaultStyle(style)).isFalse
+        }
+    }
+
+    @Test
+    fun `should create style with thin border`(): Unit {
+        // given
+        val borderedStyle = ExportCellStyle(border = ExportBorder.THIN)
+
+        // when
+        val style = factory.getStyle(borderedStyle)
+
+        // then
+        assertThat(style.borderTop).isEqualTo(BorderStyle.THIN)
+        assertThat(style.borderBottom).isEqualTo(BorderStyle.THIN)
+        assertThat(style.borderLeft).isEqualTo(BorderStyle.THIN)
+        assertThat(style.borderRight).isEqualTo(BorderStyle.THIN)
+    }
+
+    @Test
+    fun `should create style with medium border`(): Unit {
+        // given
+        val borderedStyle = ExportCellStyle(border = ExportBorder.MEDIUM)
+
+        // when
+        val style = factory.getStyle(borderedStyle)
+
+        // then
+        assertThat(style.borderTop).isEqualTo(BorderStyle.MEDIUM)
+        assertThat(style.borderBottom).isEqualTo(BorderStyle.MEDIUM)
+        assertThat(style.borderLeft).isEqualTo(BorderStyle.MEDIUM)
+        assertThat(style.borderRight).isEqualTo(BorderStyle.MEDIUM)
+    }
+
+    @Test
+    fun `should create style with custom border color`(): Unit {
+        // given
+        val borderedStyle = ExportCellStyle(
+            border = ExportBorder.THIN,
+            borderColor = ExportColor.RED,
+        )
+
+        // when
+        val style = factory.getStyle(borderedStyle)
+
+        // then
+        assertThat(style.borderTop).isEqualTo(BorderStyle.THIN)
+        assertThat(style.topBorderColor).isEqualTo(ExportColor.RED.index)
+        assertThat(style.bottomBorderColor).isEqualTo(ExportColor.RED.index)
+        assertThat(style.leftBorderColor).isEqualTo(ExportColor.RED.index)
+        assertThat(style.rightBorderColor).isEqualTo(ExportColor.RED.index)
+    }
+
+    @Test
+    fun `should not apply border color when border is NONE`(): Unit {
+        // given
+        val noBorderStyle = ExportCellStyle(
+            border = ExportBorder.NONE,
+            borderColor = ExportColor.RED,
+        )
+
+        // when
+        val style = factory.getStyle(noBorderStyle)
+
+        // then
+        assertThat(style.borderTop).isEqualTo(BorderStyle.NONE)
+        assertThat(style.borderBottom).isEqualTo(BorderStyle.NONE)
+    }
+
+    @Test
+    fun `should create different styles for different border configurations`(): Unit {
+        // given
+        val thinBorder = ExportCellStyle(border = ExportBorder.THIN)
+        val mediumBorder = ExportCellStyle(border = ExportBorder.MEDIUM)
+
+        // when
+        val style1 = factory.getStyle(thinBorder)
+        val style2 = factory.getStyle(mediumBorder)
+
+        // then
+        assertThat(style1).isNotSameAs(style2)
+    }
+}

--- a/modules/infrastructure/src/test/kotlin/io/glory/infrastructure/export/excel/ExcelExporterTest.kt
+++ b/modules/infrastructure/src/test/kotlin/io/glory/infrastructure/export/excel/ExcelExporterTest.kt
@@ -1,0 +1,220 @@
+package io.glory.infrastructure.export.excel
+
+import io.glory.infrastructure.export.ColumnMetaExtractor
+import io.glory.infrastructure.export.annotation.ExportColumn
+import io.glory.infrastructure.export.annotation.ExportSheet
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class ExcelExporterTest {
+
+    private lateinit var exporter: ExcelExporter
+
+    @BeforeEach
+    fun setUp(): Unit {
+        exporter = ExcelExporter()
+        ColumnMetaExtractor.clearCache()
+    }
+
+    @Test
+    fun `should export simple data to excel`(): Unit {
+        // given
+        val data = listOf(
+            SimpleDto(name = "홍길동", age = 30),
+            SimpleDto(name = "김철수", age = 25),
+        )
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, SimpleDto::class, outputStream)
+
+        // then
+        val workbook = XSSFWorkbook(ByteArrayInputStream(outputStream.toByteArray()))
+        val sheet = workbook.getSheetAt(0)
+
+        assertThat(sheet.sheetName).isEqualTo("Sheet1")
+        assertThat(sheet.getRow(0).getCell(0).stringCellValue).isEqualTo("이름")
+        assertThat(sheet.getRow(0).getCell(1).stringCellValue).isEqualTo("나이")
+        assertThat(sheet.getRow(1).getCell(0).stringCellValue).isEqualTo("홍길동")
+        assertThat(sheet.getRow(1).getCell(1).numericCellValue).isEqualTo(30.0)
+        assertThat(sheet.getRow(2).getCell(0).stringCellValue).isEqualTo("김철수")
+        assertThat(sheet.getRow(2).getCell(1).numericCellValue).isEqualTo(25.0)
+
+        workbook.close()
+    }
+
+    @Test
+    fun `should export with custom sheet name`(): Unit {
+        // given
+        val data = listOf(CustomSheetDto(value = "test"))
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, CustomSheetDto::class, outputStream)
+
+        // then
+        val workbook = XSSFWorkbook(ByteArrayInputStream(outputStream.toByteArray()))
+        assertThat(workbook.getSheetAt(0).sheetName).isEqualTo("커스텀시트")
+        workbook.close()
+    }
+
+    @Test
+    fun `should export with index column when includeIndex is true`(): Unit {
+        // given
+        val data = listOf(
+            IndexedDto(name = "첫번째"),
+            IndexedDto(name = "두번째"),
+        )
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, IndexedDto::class, outputStream)
+
+        // then
+        val workbook = XSSFWorkbook(ByteArrayInputStream(outputStream.toByteArray()))
+        val sheet = workbook.getSheetAt(0)
+
+        assertThat(sheet.getRow(0).getCell(0).stringCellValue).isEqualTo("No.")
+        assertThat(sheet.getRow(0).getCell(1).stringCellValue).isEqualTo("이름")
+        assertThat(sheet.getRow(1).getCell(0).numericCellValue).isEqualTo(1.0)
+        assertThat(sheet.getRow(2).getCell(0).numericCellValue).isEqualTo(2.0)
+
+        workbook.close()
+    }
+
+    @Test
+    fun `should export various types correctly`(): Unit {
+        // given
+        val data = listOf(
+            VariousTypesDto(
+                text = "텍스트",
+                number = 1000,
+                decimal = BigDecimal("1234.56"),
+                date = LocalDate.of(2025, 1, 17),
+                dateTime = LocalDateTime.of(2025, 1, 17, 14, 30),
+                flag = true,
+                status = OrderStatus.COMPLETED,
+            )
+        )
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, VariousTypesDto::class, outputStream)
+
+        // then
+        val workbook = XSSFWorkbook(ByteArrayInputStream(outputStream.toByteArray()))
+        val row = workbook.getSheetAt(0).getRow(1)
+
+        assertThat(row.getCell(0).stringCellValue).isEqualTo("텍스트")
+        assertThat(row.getCell(1).numericCellValue).isEqualTo(1000.0)
+        assertThat(row.getCell(2).numericCellValue).isEqualTo(1234.56)
+        assertThat(row.getCell(3).stringCellValue).isEqualTo("2025-01-17")
+        assertThat(row.getCell(4).stringCellValue).isEqualTo("2025-01-17 14:30")
+        assertThat(row.getCell(5).stringCellValue).isEqualTo("Y")
+        assertThat(row.getCell(6).stringCellValue).isEqualTo("COMPLETED")
+
+        workbook.close()
+    }
+
+    @Test
+    fun `should export with chunks`(): Unit {
+        // given
+        val allData = (1..100).map { SimpleDto(name = "이름$it", age = it) }
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.exportWithChunks(SimpleDto::class, outputStream) { consumer ->
+            allData.chunked(30).forEach { chunk ->
+                consumer(chunk)
+            }
+        }
+
+        // then
+        val workbook = XSSFWorkbook(ByteArrayInputStream(outputStream.toByteArray()))
+        val sheet = workbook.getSheetAt(0)
+
+        assertThat(sheet.lastRowNum).isEqualTo(100) // header + 100 data rows
+        assertThat(sheet.getRow(1).getCell(0).stringCellValue).isEqualTo("이름1")
+        assertThat(sheet.getRow(100).getCell(0).stringCellValue).isEqualTo("이름100")
+
+        workbook.close()
+    }
+
+    @Test
+    fun `should sort columns by order`(): Unit {
+        // given
+        val data = listOf(OrderedDto(third = "C", first = "A", second = "B"))
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, OrderedDto::class, outputStream)
+
+        // then
+        val workbook = XSSFWorkbook(ByteArrayInputStream(outputStream.toByteArray()))
+        val headerRow = workbook.getSheetAt(0).getRow(0)
+
+        assertThat(headerRow.getCell(0).stringCellValue).isEqualTo("첫번째")
+        assertThat(headerRow.getCell(1).stringCellValue).isEqualTo("두번째")
+        assertThat(headerRow.getCell(2).stringCellValue).isEqualTo("세번째")
+
+        workbook.close()
+    }
+
+    // Test DTOs
+
+    data class SimpleDto(
+        @ExportColumn(header = "이름", order = 1)
+        val name: String,
+        @ExportColumn(header = "나이", order = 2)
+        val age: Int,
+    )
+
+    @ExportSheet(name = "커스텀시트")
+    data class CustomSheetDto(
+        @ExportColumn(header = "값", order = 1)
+        val value: String,
+    )
+
+    @ExportSheet(includeIndex = true)
+    data class IndexedDto(
+        @ExportColumn(header = "이름", order = 1)
+        val name: String,
+    )
+
+    data class VariousTypesDto(
+        @ExportColumn(header = "텍스트", order = 1)
+        val text: String,
+        @ExportColumn(header = "숫자", order = 2)
+        val number: Int,
+        @ExportColumn(header = "소수", order = 3)
+        val decimal: BigDecimal,
+        @ExportColumn(header = "날짜", order = 4)
+        val date: LocalDate,
+        @ExportColumn(header = "일시", order = 5, format = "yyyy-MM-dd HH:mm")
+        val dateTime: LocalDateTime,
+        @ExportColumn(header = "플래그", order = 6)
+        val flag: Boolean,
+        @ExportColumn(header = "상태", order = 7)
+        val status: OrderStatus,
+    )
+
+    data class OrderedDto(
+        @ExportColumn(header = "세번째", order = 3)
+        val third: String,
+        @ExportColumn(header = "첫번째", order = 1)
+        val first: String,
+        @ExportColumn(header = "두번째", order = 2)
+        val second: String,
+    )
+
+    enum class OrderStatus {
+        PENDING, COMPLETED, CANCELLED
+    }
+}

--- a/modules/infrastructure/src/test/kotlin/io/glory/infrastructure/export/excel/JavaDtoExportTest.kt
+++ b/modules/infrastructure/src/test/kotlin/io/glory/infrastructure/export/excel/JavaDtoExportTest.kt
@@ -1,0 +1,56 @@
+package io.glory.infrastructure.export.excel
+
+import io.glory.infrastructure.export.ColumnMetaExtractor
+import io.glory.infrastructure.export.JavaExportDto
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+class JavaDtoExportTest {
+
+    private lateinit var exporter: ExcelExporter
+
+    @BeforeEach
+    fun setUp(): Unit {
+        exporter = ExcelExporter()
+        ColumnMetaExtractor.clearCache()
+    }
+
+    @Test
+    fun `should export Java DTO to excel`(): Unit {
+        // given
+        val data = listOf(
+            JavaExportDto("홍길동", 30),
+            JavaExportDto("김철수", 25),
+        )
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, JavaExportDto::class, outputStream)
+
+        // then
+        val workbook = XSSFWorkbook(ByteArrayInputStream(outputStream.toByteArray()))
+        val sheet = workbook.getSheetAt(0)
+
+        assertThat(sheet.sheetName).isEqualTo("자바DTO")
+        assertThat(sheet.getRow(0).getCell(0).stringCellValue).isEqualTo("이름")
+        assertThat(sheet.getRow(0).getCell(1).stringCellValue).isEqualTo("나이")
+        assertThat(sheet.getRow(1).getCell(0).stringCellValue).isEqualTo("홍길동")
+        assertThat(sheet.getRow(1).getCell(1).numericCellValue).isEqualTo(30.0)
+
+        workbook.close()
+    }
+
+    @Test
+    fun `should extract column metas from Java class`(): Unit {
+        // when
+        val metas = ColumnMetaExtractor.extractColumnMetas(JavaExportDto::class)
+
+        // then
+        println("Extracted metas: $metas")
+        assertThat(metas).isNotEmpty
+    }
+}

--- a/modules/infrastructure/src/test/kotlin/io/glory/infrastructure/export/excel/JavaDtoExportTest.kt
+++ b/modules/infrastructure/src/test/kotlin/io/glory/infrastructure/export/excel/JavaDtoExportTest.kt
@@ -2,6 +2,12 @@ package io.glory.infrastructure.export.excel
 
 import io.glory.infrastructure.export.ColumnMetaExtractor
 import io.glory.infrastructure.export.JavaExportDto
+import io.glory.infrastructure.export.JavaRecordDto
+import io.glory.infrastructure.export.JavaStyledRecordDto
+import io.glory.infrastructure.export.annotation.ExportAlignment
+import io.glory.infrastructure.export.annotation.ExportColor
+import org.apache.poi.ss.usermodel.FillPatternType
+import org.apache.poi.ss.usermodel.HorizontalAlignment
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -50,7 +56,123 @@ class JavaDtoExportTest {
         val metas = ColumnMetaExtractor.extractColumnMetas(JavaExportDto::class)
 
         // then
-        println("Extracted metas: $metas")
         assertThat(metas).isNotEmpty
+        assertThat(metas).hasSize(2)
+    }
+
+    @Test
+    fun `should export Java record to excel`(): Unit {
+        // given
+        val data = listOf(
+            JavaRecordDto("노트북", 1500000, 10, true),
+            JavaRecordDto("마우스", 35000, 100, true),
+            JavaRecordDto("키보드", 89000, 0, false),
+        )
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, JavaRecordDto::class, outputStream)
+
+        // then
+        val workbook = XSSFWorkbook(ByteArrayInputStream(outputStream.toByteArray()))
+        val sheet = workbook.getSheetAt(0)
+
+        // sheet name
+        assertThat(sheet.sheetName).isEqualTo("자바레코드")
+
+        // headers
+        assertThat(sheet.getRow(0).getCell(0).stringCellValue).isEqualTo("상품명")
+        assertThat(sheet.getRow(0).getCell(1).stringCellValue).isEqualTo("가격")
+        assertThat(sheet.getRow(0).getCell(2).stringCellValue).isEqualTo("재고")
+        assertThat(sheet.getRow(0).getCell(3).stringCellValue).isEqualTo("판매중")
+
+        // data row 1
+        assertThat(sheet.getRow(1).getCell(0).stringCellValue).isEqualTo("노트북")
+        assertThat(sheet.getRow(1).getCell(1).numericCellValue).isEqualTo(1500000.0)
+        assertThat(sheet.getRow(1).getCell(2).numericCellValue).isEqualTo(10.0)
+        assertThat(sheet.getRow(1).getCell(3).stringCellValue).isEqualTo("Y")
+
+        // data row 3 (out of stock)
+        assertThat(sheet.getRow(3).getCell(0).stringCellValue).isEqualTo("키보드")
+        assertThat(sheet.getRow(3).getCell(2).numericCellValue).isEqualTo(0.0)
+        assertThat(sheet.getRow(3).getCell(3).stringCellValue).isEqualTo("N")
+
+        workbook.close()
+    }
+
+    @Test
+    fun `should extract column metas from Java record`(): Unit {
+        // when
+        val metas = ColumnMetaExtractor.extractColumnMetas(JavaRecordDto::class)
+
+        // then
+        assertThat(metas).hasSize(4)
+        assertThat(metas.map { it.header }).containsExactly("상품명", "가격", "재고", "판매중")
+    }
+
+    @Test
+    fun `should apply format to Java record fields`(): Unit {
+        // given
+        val data = listOf(JavaRecordDto("테스트상품", 1234567, 50, true))
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, JavaRecordDto::class, outputStream)
+
+        // then
+        val workbook = XSSFWorkbook(ByteArrayInputStream(outputStream.toByteArray()))
+        val sheet = workbook.getSheetAt(0)
+        val priceCell = sheet.getRow(1).getCell(1)
+
+        // verify numeric value is set
+        assertThat(priceCell.numericCellValue).isEqualTo(1234567.0)
+
+        workbook.close()
+    }
+
+    @Test
+    fun `should apply custom header style to Java record`(): Unit {
+        // given
+        val data = listOf(JavaStyledRecordDto("노트북", 1500000, "판매중"))
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, JavaStyledRecordDto::class, outputStream)
+
+        // then
+        val workbook = XSSFWorkbook(ByteArrayInputStream(outputStream.toByteArray()))
+        val sheet = workbook.getSheetAt(0)
+
+        // header row - 상품명 (LIGHT_BLUE background, CENTER alignment)
+        val productNameHeader = sheet.getRow(0).getCell(0)
+        assertThat(productNameHeader.cellStyle.fillForegroundColor).isEqualTo(ExportColor.LIGHT_BLUE.index)
+        assertThat(productNameHeader.cellStyle.fillPattern).isEqualTo(FillPatternType.SOLID_FOREGROUND)
+        assertThat(productNameHeader.cellStyle.alignment).isEqualTo(HorizontalAlignment.CENTER)
+
+        // header row - 가격 (LIGHT_GREEN background)
+        val priceHeader = sheet.getRow(0).getCell(1)
+        assertThat(priceHeader.cellStyle.fillForegroundColor).isEqualTo(ExportColor.LIGHT_GREEN.index)
+
+        workbook.close()
+    }
+
+    @Test
+    fun `should apply custom body style to Java record`(): Unit {
+        // given
+        val data = listOf(JavaStyledRecordDto("노트북", 1500000, "판매중"))
+        val outputStream = ByteArrayOutputStream()
+
+        // when
+        exporter.export(data, JavaStyledRecordDto::class, outputStream)
+
+        // then
+        val workbook = XSSFWorkbook(ByteArrayInputStream(outputStream.toByteArray()))
+        val sheet = workbook.getSheetAt(0)
+
+        // body row - 가격 (RIGHT alignment)
+        val priceCell = sheet.getRow(1).getCell(1)
+        assertThat(priceCell.cellStyle.alignment).isEqualTo(HorizontalAlignment.RIGHT)
+
+        workbook.close()
     }
 }


### PR DESCRIPTION
## Summary

Implement annotation-based Excel/CSV export functionality with comprehensive cell styling support. This feature enables exporting data classes to Excel (.xlsx) and CSV files using simple annotations.

## Changes

### Phase 1: Core Export
- Add `@ExportSheet` and `@ExportColumn` annotations for declarative export configuration
- Implement `ExcelExporter` with SXSSF streaming for large datasets
- Implement `CsvExporter` for lightweight CSV exports
- Add `ValueConverter` for type-safe cell value conversion
- Add `ColumnMetaExtractor` for annotation processing

### Phase 2: Styling Support
- Add `@ExportCellStyle` annotation with font, color, alignment, border options
- Add `ExportColor`, `ExportAlignment`, `ExportBorder` enums
- Implement `CellStyleFactory` with style caching (POI 64K limit handling)
- Support `headerStyle` and `bodyStyle` in `@ExportColumn`
- Add Java record/class compatibility

### Tests
- 62 comprehensive tests covering all export scenarios
- Java DTO and Record export tests
- Style application and caching tests

## Test Plan

- [x] Run all export tests: `./gradlew :modules:infrastructure:test --tests "io.glory.infrastructure.export.*"`
- [x] Verify Excel file generation with styling
- [x] Verify CSV file generation
- [x] Verify Java record support

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/code)